### PR TITLE
Form completion

### DIFF
--- a/src/UDS.Net.Forms/DataAnnotations/BirthMonthAttribute.cs
+++ b/src/UDS.Net.Forms/DataAnnotations/BirthMonthAttribute.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using UDS.Net.Forms.Models;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.DataAnnotations
 {
@@ -34,7 +35,7 @@ namespace UDS.Net.Forms.DataAnnotations
                 var form = (FormModel)validationContext.ObjectInstance;
 
                 // only validate if the form is attempting to be completed
-                if (form.Status == "2") // TODO change statuses to enum
+                if (form.Status == FormStatus.Complete)
                 {
                     // Only validate on the server if form is attempting to be completed
                     var month = (int)value;

--- a/src/UDS.Net.Forms/DataAnnotations/BirthYearAttribute.cs
+++ b/src/UDS.Net.Forms/DataAnnotations/BirthYearAttribute.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using UDS.Net.Forms.Models;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.DataAnnotations
 {
@@ -36,7 +37,7 @@ namespace UDS.Net.Forms.DataAnnotations
             {
                 var form = (FormModel)validationContext.ObjectInstance;
 
-                if (form.Status == "2") // TODO fix statuses
+                if (form.Status == FormStatus.Complete)
                 {
                     // Only validate on the server if form is attempting to be completed
                     var year = (int)value;

--- a/src/UDS.Net.Forms/DataAnnotations/DiagnosisAttribute.cs
+++ b/src/UDS.Net.Forms/DataAnnotations/DiagnosisAttribute.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using UDS.Net.Forms.Models;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.DataAnnotations
 {
@@ -19,7 +20,7 @@ namespace UDS.Net.Forms.DataAnnotations
 
 
                 // only validate if the form is attempting to be completed
-                if (form.Status == "2") // TODO change statuses to enum
+                if (form.Status == FormStatus.Complete)
                 {
                     if (value is int)
                     {

--- a/src/UDS.Net.Forms/DataAnnotations/RequiredIfAttribute.cs
+++ b/src/UDS.Net.Forms/DataAnnotations/RequiredIfAttribute.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using UDS.Net.Forms.Models;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.DataAnnotations
 {
@@ -27,7 +28,7 @@ namespace UDS.Net.Forms.DataAnnotations
                 var form = (FormModel)validationContext.ObjectInstance;
 
                 // only validate if the form is attempting to be completed
-                if (form.Status == "2") // TODO change statuses to enum
+                if (form.Status == FormStatus.Complete)
                 {
                     // get the watched property and compare
                     var type = validationContext.ObjectType;

--- a/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
@@ -21,13 +21,12 @@ namespace UDS.Net.Forms.Extensions
         {
             vm.VisitId = form.VisitId;
             vm.Version = form.Version;
-            vm.Status = form.Status; // TODO
+            vm.Status = form.Status;
             vm.Kind = form.Kind;
             vm.Title = form.Title;
             vm.Description = form.Description;
             vm.IsRequiredForVisitKind = form.IsRequiredForVisitKind;
-            vm.IncludeInPacketSubmission = form.IsIncluded.HasValue ? form.IsIncluded.Value : false;
-            vm.ReasonNotIncluded = form.ReasonCode;
+            vm.ReasonCodeNotIncluded = form.ReasonCode;
             vm.CreatedAt = form.CreatedAt;
             vm.CreatedBy = form.CreatedBy;
             vm.ModifiedBy = form.ModifiedBy;
@@ -101,7 +100,6 @@ namespace UDS.Net.Forms.Extensions
                 Title = form.Title,
                 Description = form.Description,
                 IsRequiredForVisitKind = form.IsRequiredForVisitKind,
-                IncludeInPacketSubmission = form.IsIncluded.HasValue ? form.IsIncluded.Value : false,
                 CreatedAt = form.CreatedAt,
                 CreatedBy = form.CreatedBy,
                 ModifiedBy = form.ModifiedBy,

--- a/src/UDS.Net.Forms/Extensions/ViewModelToDomainMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/ViewModelToDomainMapper.cs
@@ -70,7 +70,7 @@ namespace UDS.Net.Forms.Extensions
             else if (vm is T1)
                 return ((T1)vm).ToEntity();
             else
-                return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, null);
+                return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, null);
         }
 
         public static Form ToEntity(this A1 vm)
@@ -105,7 +105,7 @@ namespace UDS.Net.Forms.Extensions
                 HANDED = vm.HANDED
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this A2 vm)
@@ -133,7 +133,7 @@ namespace UDS.Net.Forms.Extensions
                 INRELY = vm.INRELY
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this A3 vm)
@@ -174,7 +174,7 @@ namespace UDS.Net.Forms.Extensions
                 KidsFormFields = vm.Children.Select(c => c.ToEntity()).ToList()
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static A3FamilyMemberFormFields ToEntity(this A3FamilyMember vm)
@@ -200,7 +200,7 @@ namespace UDS.Net.Forms.Extensions
                 A4Ds = vm.DrugIds.Select(d => d.ToEntity()).ToList()
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static A4DFormFields ToEntity(this string drugId)
@@ -283,7 +283,7 @@ namespace UDS.Net.Forms.Extensions
                 PSYCDISX = vm.PSYCDISX
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this B1 vm)
@@ -303,7 +303,7 @@ namespace UDS.Net.Forms.Extensions
                 HEARWAID = vm.HEARWAID
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this B4 vm)
@@ -322,7 +322,7 @@ namespace UDS.Net.Forms.Extensions
                 CDRLANG = vm.CDRLANG,
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this B5 vm)
@@ -357,7 +357,7 @@ namespace UDS.Net.Forms.Extensions
                 APPSEV = vm.APPSEV
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this B6 vm)
@@ -383,7 +383,7 @@ namespace UDS.Net.Forms.Extensions
                 GDS = vm.GDS
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this B7 vm)
@@ -402,7 +402,7 @@ namespace UDS.Net.Forms.Extensions
                 TRAVEL = vm.TRAVEL
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this B8 vm)
@@ -455,7 +455,7 @@ namespace UDS.Net.Forms.Extensions
                 OTHNEURX = vm.OTHNEURX
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this B9 vm)
@@ -521,7 +521,7 @@ namespace UDS.Net.Forms.Extensions
                 FTLDEVAL = vm.FTLDEVAL
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this C1 vm)
@@ -577,7 +577,7 @@ namespace UDS.Net.Forms.Extensions
                 COGSTAT = vm.COGSTAT
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this C2 vm)
@@ -656,7 +656,7 @@ namespace UDS.Net.Forms.Extensions
                 COGSTAT = vm.COGSTAT
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this D1 vm)
@@ -794,7 +794,7 @@ namespace UDS.Net.Forms.Extensions
                 COGOTH3X = vm.COGOTH3X
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this D2 vm)
@@ -836,7 +836,7 @@ namespace UDS.Net.Forms.Extensions
                 OTHCONDX = vm.OTHCONDX
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
 
         public static Form ToEntity(this T1 vm)
@@ -855,7 +855,7 @@ namespace UDS.Net.Forms.Extensions
                 TELMILE = vm.TELMILE
             };
 
-            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.IncludeInPacketSubmission, vm.ReasonCodeNotIncluded.ToString(), vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
+            return new Form(vm.VisitId, vm.Id, vm.Title, vm.Kind, vm.Status, vm.Language, vm.ReasonCodeNotIncluded, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, vm.DeletedBy, vm.IsDeleted, fields);
         }
     }
 }

--- a/src/UDS.Net.Forms/Models/FormModel.cs
+++ b/src/UDS.Net.Forms/Models/FormModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using UDS.Net.Forms.DataAnnotations;
 using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.Models
@@ -9,37 +10,79 @@ namespace UDS.Net.Forms.Models
     {
         public int Id { get; set; }
 
+        [Required]
         public int VisitId { get; set; }
 
+        [Required]
         public string Kind { get; set; } = "";
 
+        [Required]
         public string Version { get; set; } = "";
 
         public string Title { get; set; } = "";
 
         public string Description { get; set; } = "";
 
+        [Required(ErrorMessage = "Choose whether to save in-progress or complete the form")]
+        [Display(Name = "Status")]
         public FormStatus Status { get; set; }
 
         public bool IsRequiredForVisitKind { get; set; }
 
+        [Display(Name = "Language")]
         public FormLanguage Language { get; set; }
 
+        [Display(Name = "If not submitted, specify reason")]
         public ReasonCode? ReasonCodeNotIncluded { get; set; }
 
+        [Required]
         public DateTime CreatedAt { get; set; }
 
+        [Required]
         public string CreatedBy { get; set; } = "";
 
         public string? ModifiedBy { get; set; }
 
         public string? DeletedBy { get; set; }
 
+        [Required]
         public bool IsDeleted { get; set; }
 
         public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            throw new Exception("Cannot validate without full object.");
+            if (Status == FormStatus.NotStarted)
+            {
+                yield return new ValidationResult(
+                    $"Choose status to save form",
+                    new[] { nameof(Status) });
+            }
+            else if (Status == FormStatus.NotIncluded && !ReasonCodeNotIncluded.HasValue)
+            {
+                yield return new ValidationResult(
+                    $"Provide a reason code if form is not included",
+                    new[] { nameof(ReasonCodeNotIncluded) });
+            }
+            else if (Status == FormStatus.Complete)
+            {
+                if (string.IsNullOrWhiteSpace(Kind.Trim()))
+                {
+                    yield return new ValidationResult(
+                        $"Form kind is required",
+                        new[] { nameof(ReasonCodeNotIncluded) });
+                }
+                if (string.IsNullOrWhiteSpace(Version.Trim()))
+                {
+                    yield return new ValidationResult(
+                        $"Form version is required",
+                        new[] { nameof(ReasonCodeNotIncluded) });
+                }
+                if (string.IsNullOrWhiteSpace(CreatedBy.Trim()))
+                {
+                    yield return new ValidationResult(
+                        $"Created by is required",
+                        new[] { nameof(ReasonCodeNotIncluded) });
+                }
+            }
         }
     }
 }

--- a/src/UDS.Net.Forms/Models/FormModel.cs
+++ b/src/UDS.Net.Forms/Models/FormModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.Models
 {
@@ -18,17 +19,13 @@ namespace UDS.Net.Forms.Models
 
         public string Description { get; set; } = "";
 
-        public string Status { get; set; } = "";
+        public FormStatus Status { get; set; }
 
         public bool IsRequiredForVisitKind { get; set; }
 
-        public string? Language { get; set; }
+        public FormLanguage Language { get; set; }
 
-        public bool IncludeInPacketSubmission { get; set; }
-
-        public int? ReasonCodeNotIncluded { get; set; }
-
-        public string? ReasonNotIncluded { get; set; }
+        public ReasonCode? ReasonCodeNotIncluded { get; set; }
 
         public DateTime CreatedAt { get; set; }
 

--- a/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
+++ b/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
@@ -33,7 +33,7 @@ namespace UDS.Net.Forms.Models.PageModels
 
         protected readonly IVisitService _visitService;
         protected string _formKind { get; set; }
-        protected FormModel _formModel;
+        public FormModel _formModel;
 
         public FormPageModel(IVisitService visitService, string formKind) : base()
         {

--- a/src/UDS.Net.Forms/Models/UDS3/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/A1.cs
@@ -126,6 +126,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/A2.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/A2.cs
@@ -83,11 +83,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (Status == "Complete" && IsRequiredForVisitKind && IncludeInPacketSubmission == false)
+            if (Status == Services.Enums.FormStatus.Complete && IsRequiredForVisitKind)
             {
                 yield return new ValidationResult(
-                    $"Form is required for visit and is not optional",
-                    new[] { nameof(IncludeInPacketSubmission) });
+                    $"Form is required for visit and must be included in submission",
+                    new[] { nameof(Status) });
             }
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/A2.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/A2.cs
@@ -83,12 +83,12 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (Status == Services.Enums.FormStatus.Complete && IsRequiredForVisitKind)
+            foreach (var result in base.Validate(validationContext))
             {
-                yield return new ValidationResult(
-                    $"Form is required for visit and must be included in submission",
-                    new[] { nameof(Status) });
+                yield return result;
             }
+
+            yield break;
         }
     }
 }

--- a/src/UDS.Net.Forms/Models/UDS3/A3.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/A3.cs
@@ -156,9 +156,15 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public List<A3FamilyMember> Children { get; set; } = new List<A3FamilyMember>();
 
+        // Validation in these scenarios
+        // - cross-form validation
+        // - differences in validation across visit types for instance, IVP vs FVP
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            var type = validationContext.ObjectType;
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
 
             yield break;
         }

--- a/src/UDS.Net.Forms/Models/UDS3/A4.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/A4.cs
@@ -15,6 +15,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/A5.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/A5.cs
@@ -214,6 +214,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/B1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/B1.cs
@@ -51,6 +51,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/B4.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/B4.cs
@@ -41,6 +41,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/B5.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/B5.cs
@@ -81,6 +81,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/B6.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/B6.cs
@@ -78,6 +78,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/B7.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/B7.cs
@@ -40,6 +40,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/B8.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/B8.cs
@@ -142,6 +142,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/B9.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/B9.cs
@@ -256,6 +256,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -188,6 +188,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             if (Status == FormStatus.Complete)
             {
                 bool isValid = false;

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using UDS.Net.Forms.DataAnnotations;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.Models.UDS3
 {
@@ -188,7 +188,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (Status == "2")
+            if (Status == FormStatus.Complete)
             {
                 bool isValid = false;
                 string errorMessage = "Logical Memory IA -Immediate previous test date should be within the previous 3 months of the visit date";

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -197,44 +197,68 @@ namespace UDS.Net.Forms.Models.UDS3
             {
                 bool isValid = false;
                 string errorMessage = "Logical Memory IA -Immediate previous test date should be within the previous 3 months of the visit date";
-                var visitDateEntry = validationContext.Items.Where(i => i.Key.ToString() == "VisitDate").FirstOrDefault();
+
                 if (LOGIPREV.HasValue && LOGIPREV != 88)
                 {
+                    // If the test was performed in the last 3 months then confirm the date falls within the range
+
                     if (LOGIYR.HasValue && LOGIMO.HasValue && LOGIDAY.HasValue)
                     {
-                        // we need the visit date
-                        var visitDate = visitDateEntry.Value;
-                        if (visitDate != null)
+                        if (validationContext.Items.Where(v => v.Key.ToString() == "Visit").Any())
                         {
-                            var max = (DateTime)visitDate;
-                            var min = ((DateTime)visitDate).AddMonths(-3);
-
-                            try
+                            var visitValue = validationContext.Items.FirstOrDefault(v => v.Key.ToString() == "Visit").Value;
+                            if (visitValue is VisitModel)
                             {
-                                var logiDate = new DateTime(LOGIYR.Value, LOGIMO.Value, LOGIDAY.Value);
+                                VisitModel visit = (VisitModel)visitValue;
+                                var visitDateEntry = visit.StartDateTime;
 
-                                var resultHigh = DateTime.Compare(logiDate, max);
-                                var resultLow = DateTime.Compare(logiDate, min);
-
-                                if (resultHigh < 0 && resultLow > 0)
+                                // we need the visit date
+                                var visitDate = visitDateEntry;
+                                if (visitDate != null)
                                 {
-                                    isValid = true;
+                                    var max = (DateTime)visitDate;
+                                    var min = ((DateTime)visitDate).AddMonths(-3);
+
+                                    try
+                                    {
+                                        var logiDate = new DateTime(LOGIYR.Value, LOGIMO.Value, LOGIDAY.Value);
+
+                                        var resultHigh = DateTime.Compare(logiDate, max);
+                                        var resultLow = DateTime.Compare(logiDate, min);
+
+                                        if (resultHigh < 0 && resultLow > 0)
+                                        {
+                                            isValid = true;
+                                        }
+
+                                        else
+                                        {
+                                            isValid = false;
+                                        }
+                                    }
+                                    catch (ArgumentOutOfRangeException ex)
+                                    {
+                                        // not a valid date
+                                        isValid = false;
+                                        errorMessage = "Logical Memory IA - Immediate previous test date invalid";
+                                    }
                                 }
 
-                                else
-                                {
-                                    isValid = false;
-                                }
-                            }
-                            catch (ArgumentOutOfRangeException ex)
-                            {
-                                // not a valid date
-                                isValid = false;
-                                errorMessage = "Logical Memory IA -Immediate previous test date invalid";
                             }
                         }
+                        else
+                        {
+                            isValid = false;
+                            errorMessage = "Unable to compare against Visit date.";
+                        }
+                    }
+                    else
+                    {
+                        isValid = false;
+                        errorMessage = "Logical Memory IA - Immediate Must provide the full date of the previous test";
                     }
                 }
+
                 if (!isValid)
                 {
                     yield return new ValidationResult(

--- a/src/UDS.Net.Forms/Models/UDS3/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C2.cs
@@ -285,6 +285,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/D1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/D1.cs
@@ -409,6 +409,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/D2.cs
@@ -123,6 +123,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Models/UDS3/T1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/T1.cs
@@ -42,6 +42,11 @@ namespace UDS.Net.Forms.Models.UDS3
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
+            foreach (var result in base.Validate(validationContext))
+            {
+                yield return result;
+            }
+
             yield break;
         }
     }

--- a/src/UDS.Net.Forms/Pages/Shared/_FormFooter.cshtml
+++ b/src/UDS.Net.Forms/Pages/Shared/_FormFooter.cshtml
@@ -25,8 +25,6 @@
                 <input asp-for="Title" type="hidden" />
                 <input asp-for="Description" type="hidden" />
                 <input asp-for="IsRequiredForVisitKind" type="hidden" />
-                <input asp-for="IncludeInPacketSubmission" type="hidden" />
-                <input asp-for="ReasonNotIncluded" type="hidden" />
                 <input asp-for="CreatedAt" type="hidden" />
                 <input asp-for="CreatedBy" type="hidden" />
                 <input asp-for="ModifiedBy" type="hidden" />

--- a/src/UDS.Net.Forms/Pages/Shared/_FormFooter.cshtml
+++ b/src/UDS.Net.Forms/Pages/Shared/_FormFooter.cshtml
@@ -2,42 +2,74 @@
 @{
 }
 
-<div class="shadow sm:rounded-lg bg-indigo-100">
-    <div class="px-4 py-5 sm:p-6">
-
-        <div asp-validation-summary="All" class="mt-1 text-sm text-red-700">
-            <p></p>
+@if (Model != null)
+{
+    <div class="mx-auto grid max-w-7xl grid-cols-1 lg:grid-cols-2">
+        <div class="relative px-6 pb-20 pt-12 sm:pt-12 lg:static lg:px-8 lg:py-12">
+            <div class="mx-auto max-w-xl lg:mx-0 lg:max-w-lg">
+                <h2 class="text-3xl font-bold tracking-tight text-gray-900">Complete this form</h2>
+                <p class="mt-6 text-lg leading-8 text-gray-600">You can partially save the form <i>in-progress</i> if you're in a hurry and wish to return and finish it later, otherwise, choose <i>Complete</i> and resolve any validation errors.</p>
+            </div>
+            <div asp-validation-summary="All" class="mt-1 text-sm text-red-700">
+                <p></p>
+            </div>
         </div>
+        <div class="px-6 pb-20 pt-12 sm:pb-32 lg:px-8 lg:py-12 bg-indigo-100 shadow sm:rounded-lg">
+            <div class="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2">
 
+                <input asp-for="Id" type="hidden" />
+                <input asp-for="VisitId" type="hidden" />
+                <input asp-for="Kind" type="hidden" />
+                <input asp-for="IsRequiredForVisitKind" type="hidden" />
+                <input asp-for="Version" type="hidden" />
+                <input asp-for="Title" type="hidden" />
+                <input asp-for="Description" type="hidden" />
+                <input asp-for="IsRequiredForVisitKind" type="hidden" />
+                <input asp-for="IncludeInPacketSubmission" type="hidden" />
+                <input asp-for="ReasonNotIncluded" type="hidden" />
+                <input asp-for="CreatedAt" type="hidden" />
+                <input asp-for="CreatedBy" type="hidden" />
+                <input asp-for="ModifiedBy" type="hidden" />
+                <input asp-for="DeletedBy" type="hidden" />
+                <input asp-for="IsDeleted" type="hidden" />
 
-        <input asp-for="Id" type="hidden" />
-        <input asp-for="VisitId" type="hidden" />
-        <input asp-for="Kind" type="hidden" />
-        <input asp-for="IsRequiredForVisitKind" type="hidden" />
-        <input asp-for="Version" type="hidden" />
-        <input asp-for="Title" type="hidden" />
-        <input asp-for="Description" type="hidden" />
-        <input asp-for="IsRequiredForVisitKind" type="hidden" />
-        <input asp-for="Language" type="hidden" />
-        <input asp-for="IncludeInPacketSubmission" type="hidden" />
-        <input asp-for="ReasonCodeNotIncluded" type="hidden" />
-        <input asp-for="ReasonNotIncluded" type="hidden" />
-        <input asp-for="CreatedAt" type="hidden" />
-        <input asp-for="CreatedBy" type="hidden" />
-        <input asp-for="ModifiedBy" type="hidden" />
-        <input asp-for="DeletedBy" type="hidden" />
-        <input asp-for="IsDeleted" type="hidden" />
+                <div>
+                    <label for="@Html.IdFor(m => m.Status)" class="block text-sm font-semibold leading-6 text-gray-900">Status</label>
+                    <enum-select for="Status" data-val-status="@(Model.GetType().Name + "." + nameof(Model.Status))"></enum-select>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="Status"></span>
 
-        <div class="w-full sm:max-w-xs">
-            <label class="block text-sm font-medium leading-6 text-gray-900">Status</label>
-            @if (Model != null)
-            {
-                <select data-val-status="@(Model.GetType().Name + "." + nameof(Model.Status))" asp-for="Status" asp-items="Html.GetEnumSelectList<FormStatus>()" class="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"></select>
-            }
+                </div>
+                <div>
+                    <label for="@Html.IdFor(m => m.ReasonCodeNotIncluded)" class="block text-sm font-semibold leading-6 text-gray-800">If not submitted, specify reason</label>
 
+                    @if (Model.IsRequiredForVisitKind)
+                    {
+                        <select asp-for="ReasonCodeNotIncluded" class="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-400 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6">
+                            <option disabled selected class="disabled:opacity-75">Form is required, MUST submit</option>
+                        </select>
+                    }
+                    else
+                    {
+                        <select asp-for="ReasonCodeNotIncluded" asp-items="Html.GetEnumSelectList<ReasonCode>()" class="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6">
+                            <option disabled selected class="disabled:opacity-75">--</option>
+                        </select>
+                    }
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="ReasonCodeNotIncluded"></span>
+
+                </div>
+                <div class="sm:col-span-2">
+                    <label for="@Html.IdFor(m => m.Language)" class="block text-sm font-semibold leading-6 text-gray-900">Language</label>
+                    <select asp-for="Language" asp-items="Html.GetEnumSelectList<FormLanguage>()" class="mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"></select>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="Language"></span>
+
+                </div>
+
+            </div>
+            <div class="mt-8">
+                <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Save</button>
+            </div>
         </div>
-        <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Save</button>
-
     </div>
-</div>
 
+
+}

--- a/src/UDS.Net.Forms/Pages/UDS3/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/A1.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">A1: Participant Demographics</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by intake interviewer based on ADC scheduling records, participant interview, medical records, and proxy co-participant report (as needed). For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form A1. Check only <span class="underline">one</span> box per question.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/A1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A1.cshtml.cs
@@ -202,15 +202,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(A1);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = A1;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/A1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A1.cshtml.cs
@@ -173,9 +173,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                A1 = (A1)_formModel; // class library should always handle new instances
+                A1 = (A1)BaseForm;
             }
 
             return Page();
@@ -184,30 +184,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in A1.Validate(new ValidationContext(A1, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"A1.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = A1; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(A1); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(A1);
-
-                _formModel = A1;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/A2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/A2.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">A2: Co-participant Demographics</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by intake interviewer based on co-participant's report. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form A2. Check only <span class="underline">one</span> box per question.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/A2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A2.cshtml.cs
@@ -119,15 +119,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(A2);
 
-                await base.OnPostAsync(id);
+                _formModel = A2;
+
+                return await base.OnPostAsync(id);
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/A2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A2.cshtml.cs
@@ -96,9 +96,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                A2 = (A2)_formModel; // class library should always handle new instances
+                A2 = (A2)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -107,24 +107,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            // server validation for form fields
-            foreach (var result in A2.Validate(new ValidationContext(A2, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"A2.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = A2; // reassign bounded and derived form to base form for base method
 
-            // annotations as well in view model
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(A2);
+            Visit.Forms.Add(A2); // visit needs updated form as well
 
-                _formModel = A2;
-
-                return await base.OnPostAsync(id);
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/A3.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/A3.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">A3: Family History</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by a clinician with experience in evaluating patients with neurological problems and psychiatric conditions. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form A3.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/A3.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A3.cshtml.cs
@@ -168,9 +168,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                A3 = (A3)_formModel; // class library should always handle new instances
+                A3 = (A3)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -179,27 +179,12 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public new async Task<IActionResult> OnPostAsync(int id)
         {
-            foreach (var result in A3.Validate(new ValidationContext(A3, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"A3.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = A3; // reassign bounded and derived form to base form for base method
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(A3);
+            Visit.Forms.Add(A3); // visit needs updated form as well
 
-                _formModel = A3;
-
-                return await base.OnPostAsync(id);
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
 
-        public JsonResult ValidateYear(int year)
-        {
-            return new JsonResult(true);
-        }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/A3.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A3.cshtml.cs
@@ -181,9 +181,6 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             foreach (var result in A3.Validate(new ValidationContext(A3, null, null)))
             {
-                // Validation in these scenarios
-                // - cross-form validation
-                // - differences in validation across visit types for instance, IVP vs FVP
                 var memberName = result.MemberNames.FirstOrDefault();
                 ModelState.AddModelError($"A3.{memberName}", result.ErrorMessage);
             }
@@ -192,15 +189,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(A3);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = A3;
+
+                return await base.OnPostAsync(id);
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/A4.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">A4: Participant Medications</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician or ADC staff. The purpose of the form is to record all prescription medications taken by the subject <strong>within the two weeks before the current visit</strong>. For prescription medications not listed here, please follow the instructions at the end of this form. OTC (non-prescription) medications need not be reported; however, a short list of medications that could be either prescription or OTC follows the prescription list.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/A4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A4.cshtml.cs
@@ -58,9 +58,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                A4 = (A4)_formModel; // class library should always handle new instances
+                A4 = (A4)BaseForm; // class library should always handle new instances
             }
 
             await SetDrugCodeLookup();
@@ -71,25 +71,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public new async Task<IActionResult> OnPostAsync(int id)
         {
-            foreach (var result in A4.Validate(new ValidationContext(A4, null, null)))
-            {
-                // Validation in these scenarios
-                // - cross-form validation
-                // - differences in validation across visit types for instance, IVP vs FVP
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"A4.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = A4; // reassign bounded and derived form to base form for base method
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(A4);
+            Visit.Forms.Add(A4); // visit needs updated form as well
 
-                _formModel = A4;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/A4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A4.cshtml.cs
@@ -84,15 +84,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(A4);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = A4;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/A5.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/A5.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">A5: Participant Health History</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician or ADC staff. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form A5. Check only <span class="underline">one</span> box per question.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/A5.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A5.cshtml.cs
@@ -126,15 +126,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(A5);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = A5;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/A5.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/A5.cshtml.cs
@@ -102,9 +102,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                A5 = (A5)_formModel; // class library should always handle new instances
+                A5 = (A5)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -113,25 +113,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public new async Task<IActionResult> OnPostAsync(int id)
         {
-            foreach (var result in A5.Validate(new ValidationContext(A5, null, null)))
-            {
-                // Validation in these scenarios
-                // - cross-form validation
-                // - differences in validation across visit types for instance, IVP vs FVP
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"A5.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = A5; // reassign bounded and derived form to base form for base method
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(A5);
+            Visit.Forms.Add(A5); // visit needs updated form as well
 
-                _formModel = A5;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B1.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">B1: Evaluation Form &mdash; Physical</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B1. Check only <span class="underline">one</span> box per question.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/B1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B1.cshtml.cs
@@ -33,9 +33,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                B1 = (B1)_formModel; // class library should always handle new instances
+                B1 = (B1)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -44,25 +44,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public new async Task<IActionResult> OnPostAsync(int id)
         {
-            foreach (var result in B1.Validate(new ValidationContext(B1, null, null)))
-            {
-                // Validation in these scenarios
-                // - cross-form validation
-                // - differences in validation across visit types for instance, IVP vs FVP
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"B1.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = B1;
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(B1);
+            Visit.Forms.Add(B1);
 
-                _formModel = B1;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for domain-level business rules validation
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B1.cshtml.cs
@@ -57,15 +57,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(B1);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = B1;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/B4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B4.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">B4: CDR&reg; Plus NACC FTLD</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: For information on the required online CDR training, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B4. This form is to be completed by the clinician or other trained health professional, based on co-participant report and behavioral and neurological exam of the participant. In the extremely rare instances when no co-participant is available, the clinician or other trained health professional must complete this form using all other available information and his/her best clinical judgment. Score only as decline from previous level due to <span class="underline">cognitive loss</span>, not impairment due to other factors, such as physical disability. For further information, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B4.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/B4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B4.cshtml.cs
@@ -72,15 +72,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(B4);
 
+                _formModel = B4;
+
                 await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/B4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B4.cshtml.cs
@@ -43,9 +43,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                B4 = (B4)_formModel; // class library should always handle new instances
+                B4 = (B4)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -54,30 +54,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in B4.Validate(new ValidationContext(B4, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"A1.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = B4; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(B4); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(B4);
-
-                _formModel = B4;
-
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B5.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B5.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">B5: NPI-Q</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician or other trained health professional based on co-participant interview, as described by the training video. (This is not to be completed by the participant as a paper-and-pencil self-report.) For information on NPI-Q Interviewer Certification, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B5. Check only <span class="underline">one</span> box for each category of response.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/B5.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B5.cshtml.cs
@@ -48,9 +48,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                B5 = (B5)_formModel; // class library should always handle new instances
+                B5 = (B5)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -59,30 +59,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in B5.Validate(new ValidationContext(B5, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"B5.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = B5; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(B5); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(B5);
-
-                _formModel = B5;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B5.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B5.cshtml.cs
@@ -77,15 +77,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(B5);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = B5;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/B6.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B6.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">B6: Geriatric Depression Scale</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician or other trained health professional, based on participant response. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B6. Check only <span class="underline">one</span> box per question.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/B6.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B6.cshtml.cs
@@ -69,15 +69,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(B6);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = B6;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/B6.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B6.cshtml.cs
@@ -40,9 +40,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                B6 = (B6)_formModel; // class library should always handle new instances
+                B6 = (B6)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -51,30 +51,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in B6.Validate(new ValidationContext(B6, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"B6.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = B6; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(B6); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(B6);
-
-                _formModel = B6;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B7.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B7.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">B7: NACC Functional Assessment Scale</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician or other trained health professional, based on information provided by the co-participant. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B7. Indicate the level of performance for each activity by checking the <span class="underline">one</span> appropriate response.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/B7.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B7.cshtml.cs
@@ -65,15 +65,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(B7);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = B7;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/B7.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B7.cshtml.cs
@@ -36,9 +36,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                B7 = (B7)_formModel; // class library should always handle new instances
+                B7 = (B7)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -47,30 +47,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in B7.Validate(new ValidationContext(B7, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"B7.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = B7; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(B7); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(B7);
-
-                _formModel = B7;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">B8: Neurological Examination Findings</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form must be completed by a clinician with experience in assessing the neurological signs listed below and in attributing the observed findings to a particular syndrome. Please use your best clinical judgment in assigning the syndrome. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B8.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml
@@ -407,6 +407,7 @@
                 <div class="mt-2">
                     <input asp-for="B8.OTHNEURX" />
                 </div>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="B8.OTHNEURX"></span>
             </div>
         </div>
 

--- a/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml.cs
@@ -46,9 +46,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                B8 = (B8)_formModel; // class library should always handle new instances
+                B8 = (B8)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -57,30 +57,12 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in B8.Validate(new ValidationContext(B8, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"B8.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = B8;
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(B8);
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(B8);
+            return await base.OnPostAsync(id); // checks for domain-level business rules validation
 
-                _formModel = B8;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B8.cshtml.cs
@@ -75,15 +75,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(B8);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = B8;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/B9.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/B9.cshtml
@@ -5,7 +5,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">B9: Clinician Judgment of Symptoms</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form B9. Check only <span class="underline">one</span> box per question.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/B9.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B9.cshtml.cs
@@ -119,9 +119,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                B9 = (B9)_formModel; // class library should always handle new instances
+                B9 = (B9)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -130,30 +130,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in B9.Validate(new ValidationContext(B9, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"B9.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = B9; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(B9); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(B9);
-
-                _formModel = B9;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/B9.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/B9.cshtml.cs
@@ -148,15 +148,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(B9);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = B9;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">C1: Neuropsychological Battery Scores</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by ADC or clinic staff. For test administrationa and scoring, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form C1.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml.cs
@@ -94,15 +94,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(C1);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = C1;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml.cs
@@ -61,9 +61,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                C1 = (C1)_formModel; // class library should always handle new instances
+                C1 = (C1)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -72,34 +72,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            Dictionary<object, object?> contextDicitonary = new Dictionary<object, object?>
-            {
-                { "VisitDate", this.Visit.StartDateTime }
-            };
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in C1.Validate(new ValidationContext(C1, null, contextDicitonary)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"C1.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = C1; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(C1); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(C1);
-
-                _formModel = C1;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/C2.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">C2: Neuropsychological Battery Scores</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by ADC or clinic staff. For test administration and scoring, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form C2. Any new participants who enroll in the UDS after the implementation of UDS3 must be assessed with the new neuropsychological test battery (Form C2).
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/C2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/C2.cshtml.cs
@@ -61,9 +61,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                C2 = (C2)_formModel; // class library should always handle new instances
+                C2 = (C2)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -72,30 +72,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in C2.Validate(new ValidationContext(C2, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"C2.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = C2; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(C2); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(C2);
-
-                _formModel = C2;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/C2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/C2.cshtml.cs
@@ -90,15 +90,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(C2);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = C2;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/D1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/D1.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">D1: Clincian Diagnosis</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by the clinician. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form D1. Check only <span class="underline">one</span> box per question.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/D1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/D1.cshtml.cs
@@ -122,9 +122,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                D1 = (D1)_formModel; // class library should always handle new instances
+                D1 = (D1)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -133,30 +133,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in D1.Validate(new ValidationContext(D1, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"D1.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = D1; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(D1); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(D1);
-
-                _formModel = D1;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/D1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/D1.cshtml.cs
@@ -151,15 +151,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(D1);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = D1;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/D2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/D2.cshtml
@@ -5,7 +5,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">D2: Clinician-assessed Medical Conditions</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS: This form is to be completed by a physician, physician's assistant, nurse practitioner, or other qualified practitioner. For additional clarifications and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form D2.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/D2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/D2.cshtml.cs
@@ -69,9 +69,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                D2 = (D2)_formModel; // class library should always handle new instances
+                D2 = (D2)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -80,30 +80,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in D2.Validate(new ValidationContext(D2, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"D2.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = D2; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(D2); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(D2);
-
-                _formModel = D2;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS3/D2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/D2.cshtml.cs
@@ -98,15 +98,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(D2);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = D2;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/T1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/T1.cshtml
@@ -6,7 +6,6 @@
 }
 
 <div>
-    <h2 class="text-lg font-medium leading-6 text-gray-900">T1: Inclusion Form</h2>
     <p class="mt-1 text-sm text-gray-500">
         INSTRUCTIONS:  This form is to be completed by the clinician or clinical interviewer who will participate in the @Model.Visit.Kind. For additional clarification and examples, see <guidebook kind="@Model.Visit.Kind"></guidebook>, Form T1.
     </p>

--- a/src/UDS.Net.Forms/Pages/UDS3/T1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/T1.cshtml.cs
@@ -75,15 +75,10 @@ namespace UDS.Net.Forms.Pages.UDS3
             {
                 Visit.Forms.Add(T1);
 
-                await base.OnPostAsync(id); // checks for domain-level business rules validation
+                _formModel = T1;
+
+                return await base.OnPostAsync(id); // checks for domain-level business rules validation
             }
-
-            var visit = await _visitService.GetByIdWithForm("", id, _formKind);
-
-            if (visit == null)
-                return NotFound();
-
-            Visit = visit.ToVM();
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/UDS3/T1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/T1.cshtml.cs
@@ -46,9 +46,9 @@ namespace UDS.Net.Forms.Pages.UDS3
         {
             await base.OnGetAsync(id);
 
-            if (_formModel != null)
+            if (BaseForm != null)
             {
-                T1 = (T1)_formModel; // class library should always handle new instances
+                T1 = (T1)BaseForm; // class library should always handle new instances
             }
 
             return Page();
@@ -57,30 +57,11 @@ namespace UDS.Net.Forms.Pages.UDS3
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            /*
-             * ValidationContext describes any member on which validation is performed. It also enables
-             * custom validation to be added through any service that implements the IServiceProvider
-             * interface.
-             */
-            foreach (var result in T1.Validate(new ValidationContext(T1, null, null)))
-            {
-                var memberName = result.MemberNames.FirstOrDefault();
-                ModelState.AddModelError($"T1.{memberName}", result.ErrorMessage);
-            }
+            BaseForm = T1; // reassign bounded and derived form to base form for base method
 
-            // if model is attempting to be completed, validation against domain form rules and visit rules
-            // if not validates, return with errors
+            Visit.Forms.Add(T1); // visit needs updated form as well
 
-            if (ModelState.IsValid)
-            {
-                Visit.Forms.Add(T1);
-
-                _formModel = T1;
-
-                return await base.OnPostAsync(id); // checks for domain-level business rules validation
-            }
-
-            return Page();
+            return await base.OnPostAsync(id); // checks for validation, etc.
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
+++ b/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
@@ -98,6 +98,8 @@
                                             cssClassFormState = "text-teal-500 border-transparent";
                                     }
                                     <span class="@cssClassFormState relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border py-4 text-sm font-semibold">
+                                        @form.Status
+                                    </span>
                                 </div>
                             </div>
                         </div>

--- a/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
+++ b/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
@@ -18,26 +18,45 @@
 
         </div>
         <div class="lg:col-span-9 px-5 py-6">
-            <div class="min-w-0 flex-1">
-                <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">@Model.Visit.Kind</h2>
-                <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
-                    <div class="mt-2 flex items-center text-sm text-gray-500">
-                        <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"></path>
-                        </svg>
-                        @Model.Visit.Version
+            <div class="mx-auto max-w-7xl">
+                <div class="lg:flex lg:items-center lg:justify-between">
+
+                    <div class="min-w-0 flex-1">
+                        <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">@Model.Visit.Kind</h2>
+                        <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
+                            <div class="mt-2 flex items-center text-sm text-gray-500">
+                                <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"></path>
+                                </svg>
+                                @Model.Visit.Version
+                            </div>
+                            <div class="mt-2 flex items-center text-sm text-gray-500">
+                                <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"></path>
+                                </svg>
+                                @Model.Visit.CreatedBy
+                            </div>
+                            <div class="mt-2 flex items-center text-sm text-gray-500">
+                                <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"></path>
+                                </svg>
+                                Visit on @Model.Visit.StartDateTime.ToLongDateString()
+                            </div>
+                        </div>
                     </div>
-                    <div class="mt-2 flex items-center text-sm text-gray-500">
-                        <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"></path>
-                        </svg>
-                        @Model.Visit.CreatedBy
-                    </div>
-                    <div class="mt-2 flex items-center text-sm text-gray-500">
-                        <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                            <path fill-rule="evenodd" d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"></path>
-                        </svg>
-                        Visit on @Model.Visit.StartDateTime.ToLongDateString()
+                    <div class="mt-5 flex lg:ml-4 lg:mt-0">
+                        <span class="sm:ml-3">
+                            @{
+                                var cssClassButtonState = "bg-gray-300";
+                                // TODO enable button when visit is finalizable
+                            }
+                            <button type="button" disabled asp-page="Edit" asp-route-id="@Model.Visit.Id" class="@cssClassButtonState inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ">
+                                <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd"></path>
+                                </svg>
+                                Finalize packet
+                            </button>
+                        </span>
                     </div>
                 </div>
             </div>

--- a/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
+++ b/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
@@ -68,7 +68,9 @@
                                 </div>
                                 <div class="-ml-px flex w-0 flex-1">
                                     <a href="tel:+1-202-555-0170" class="relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border border-transparent py-4 text-sm font-semibold text-gray-900">
-                                        @form.Status
+                                        @(
+                                            form.Status
+                                        )
                                     </a>
                                 </div>
                             </div>

--- a/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
+++ b/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
@@ -86,11 +86,20 @@
                                     <a asp-page="/@Model.Visit.Version/@form.Kind" asp-route-id="@form.VisitId" asp-route-visitKind="@Model.Visit.Kind" class="relative -mr-px inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-bl-lg border border-transparent py-4 text-sm font-semibold text-gray-900">Edit</a>
                                 </div>
                                 <div class="-ml-px flex w-0 flex-1">
-                                    <a href="tel:+1-202-555-0170" class="relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border border-transparent py-4 text-sm font-semibold text-gray-900">
-                                        @(
-                                            form.Status
-                                        )
-                                    </a>
+                                    @{
+                                        var cssClassFormState = "text-gray-900";
+                                        if (form.Status == FormStatus.NotStarted)
+                                            cssClassFormState = "text-red-500 border-transparent";
+                                        else if (form.Status == FormStatus.InProgress)
+                                            cssClassFormState = "text-indigo-500 border-transparent";
+                                        else if (form.Status == FormStatus.Complete)
+                                            cssClassFormState = "text-teal-500 bg-teal-50 border-teal";
+                                        else if (form.Status == FormStatus.NotIncluded)
+                                            cssClassFormState = "text-teal-500 border-transparent";
+                                    }
+                                    <span class="@cssClassFormState relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border py-4 text-sm font-semibold">
+                                        @form.Status
+                                    </span>
                                 </div>
                             </div>
                         </div>

--- a/src/UDS.Net.Forms/TagHelpers/FormStatusEnumSelectList.cs
+++ b/src/UDS.Net.Forms/TagHelpers/FormStatusEnumSelectList.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using UDS.Net.Forms.Models;
+using UDS.Net.Services.Enums;
+
+namespace UDS.Net.Forms.TagHelpers
+{
+    [HtmlTargetElement("enum-select", Attributes = "for")]
+    public class FormStatusEnumSelectList : TagHelper
+    {
+        public IEnumerable<RadioListItem> Items { get; set; }
+
+        public ModelExpression For { get; set; }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
+
+        private string _cssClass = "mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6";
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            output.TagName = "select";
+            output.Attributes.SetAttribute("class", _cssClass);
+
+            string expression = "";
+            if (For != null)
+            {
+                // get full name from for model property
+                expression = For.Name;
+                string prefix = ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix;
+                if (!String.IsNullOrWhiteSpace(prefix))
+                    expression = prefix + "." + expression;
+
+                output.Attributes.SetAttribute("name", expression);
+                output.Attributes.SetAttribute("id", expression.Replace(".", "_"));
+            }
+            output.Attributes.SetAttribute("data-val-status", expression);
+            output.Attributes.SetAttribute("data-val", "true");
+            output.Attributes.SetAttribute("data-val-required", "Required");
+
+            output.PostContent.AppendHtml(GenerateOptions());
+
+            base.Process(context, output);
+        }
+
+        private string[] SplitCamelCase(string source)
+        {
+            return Regex.Split(source, @"(?<!^)(?=[A-Z])");
+        }
+
+        private IHtmlContent GenerateOptions()
+        {
+            var count = 4;
+            // TODO if form is required, then count = 3
+
+            var optionsBuilder = new HtmlContentBuilder(3);
+
+            foreach (int i in Enum.GetValues(typeof(FormStatus)))
+            {
+                var option = new TagBuilder("option");
+
+                string formattedName = "";
+                var name = Enum.GetName(typeof(FormStatus), i);
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    string[] split = SplitCamelCase(name);
+                    formattedName = string.Join(" ", split);
+                }
+
+                option.InnerHtml.AppendLine(formattedName);
+
+                var form = (FormModel)ViewContext.ViewData.Model;
+                if (i == (int)FormStatus.NotStarted)
+                {
+                    option.Attributes["disabled"] = "disabled";
+                    if (ViewContext.ViewData.Model != null && ViewContext.ViewData.Model is FormModel)
+                    {
+                        if (form.Id <= 0 && (form.Status == FormStatus.NotStarted.ToString() || string.IsNullOrWhiteSpace(form.Status)))
+                        {
+                            option.Attributes["selected"] = "true";
+                        }
+                    }
+                }
+                else if (i == (int)FormStatus.NotIncluded)
+                {
+                    // Only allow "Not included" on optional forms
+                    if (form.IsRequiredForVisitKind)
+                        option.Attributes["disabled"] = "disabled";
+                }
+                else
+                {
+                    // "Not started" should not be selectable, so don't have a value and therefore would be null
+                    option.Attributes["value"] = i.ToString();
+                }
+
+                optionsBuilder.AppendLine(option);
+            }
+
+            return optionsBuilder;
+        }
+    }
+}
+

--- a/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
+++ b/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
@@ -42,7 +42,7 @@
                 <div class="lg:flex lg:items-center lg:justify-between">
 
                     <div class="min-w-0 flex-1">
-                        <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">@(Model._formModel.GetType().Name): @Model._formModel.Description</h2>
+                        <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">@(Model.BaseForm.GetType().Name): @Model.BaseForm.Description</h2>
                         <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
                             <div class="mt-2 flex items-center text-sm text-gray-500">
                                 <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -54,7 +54,7 @@
                                 <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"></path>
                                 </svg>
-                                Created by @Model._formModel.CreatedBy
+                                Created by @Model.BaseForm.CreatedBy
                             </div>
                             <div class="mt-2 flex items-center text-sm text-gray-500">
                                 <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
+++ b/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
@@ -39,7 +39,7 @@
             </nav>
 
             <div class="divide-y divide-gray-200">
-                <form method="post">
+                <form method="post" id="UDSForm">
                     <input asp-for="Visit.Id" type="hidden" />
                     <input asp-for="Visit.ParticipationId" type="hidden" />
                     <input asp-for="Visit.Number" type="hidden" />

--- a/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
+++ b/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
@@ -38,6 +38,35 @@
                 </ol>
             </nav>
 
+            <div class="mx-auto max-w-7xl">
+                <div class="lg:flex lg:items-center lg:justify-between">
+
+                    <div class="min-w-0 flex-1">
+                        <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">@(Model._formModel.GetType().Name): @Model._formModel.Description</h2>
+                        <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
+                            <div class="mt-2 flex items-center text-sm text-gray-500">
+                                <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"></path>
+                                </svg>
+                                @Model.Visit.Version
+                            </div>
+                            <div class="mt-2 flex items-center text-sm text-gray-500">
+                                <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"></path>
+                                </svg>
+                                Created by @Model._formModel.CreatedBy
+                            </div>
+                            <div class="mt-2 flex items-center text-sm text-gray-500">
+                                <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"></path>
+                                </svg>
+                                Visit on @Model.Visit.CreatedAt.ToShortDateString()
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="divide-y divide-gray-200">
                 <form method="post" id="UDSForm">
                     <input asp-for="Visit.Id" type="hidden" />

--- a/src/UDS.Net.Forms/Views/Shared/_NavSidebarForms.cshtml
+++ b/src/UDS.Net.Forms/Views/Shared/_NavSidebarForms.cshtml
@@ -2,8 +2,7 @@
 @{
     var currentPath = ViewContext.RouteData.Values["page"];
 
-    string currentlySelectedAnchorCss = "bg-teal-50 border-teal-500 text-teal-700 hover:bg-teal-50 hover:text-teal-700 group border-l-4 px-3 py-2 flex items-center text-sm font-medium";
-    string notSelectedAnchorCss = "border-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900 group border-l-4 px-3 py-2 flex items-center text-sm font-medium";
+    string notSelectedAnchorCss = "border-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900";
 }
 
 @if (Model != null && Model.Forms != null)
@@ -15,10 +14,27 @@
             var cssClass = notSelectedAnchorCss;
             if (anchorPath.Trim() == currentPath.ToString().Trim())
             {
-                cssClass = currentlySelectedAnchorCss;
+                if (form.Status == FormStatus.NotStarted)
+                    cssClass = "bg-red-50 border-red-500 text-red-700 hover:bg-red-50 hover:text-red-700";
+                else if (form.Status == FormStatus.InProgress)
+                    cssClass = "bg-indigo-50 border-indigo-500 text-indigo-700 hover:bg-indigo-50 hover:text-indigo-700";
+                else if (form.Status == FormStatus.Complete)
+                    cssClass = "bg-teal-50 border-teal-500 text-teal-700 hover:bg-teal-50 hover:text-teal-700"; // text-teal-500 group-hover:text-teal-500
+                else if (form.Status == FormStatus.NotIncluded)
+                    cssClass = "bg-teal-50 border-teal-500 text-teal-700 hover:bg-teal-50 hover:text-teal-700";
             }
-            <a asp-page="/@Model.Version/@form.Kind" asp-route-id="@Model.Id" asp-route-visitKind="@Model.Kind" class="@cssClass">
-                <span class="text-teal-500 group-hover:text-teal-500 flex-shrink-0 -ml-1 mr-3 h-6 w-6">@form.Kind</span>
+            var cssClassFormState = "text-gray-500 group-hover:text-gray-500";
+            if (form.Status == FormStatus.NotStarted)
+                cssClassFormState = "text-red-500 group-hover:text-red-500";
+            else if (form.Status == FormStatus.InProgress)
+                cssClassFormState = "text-indigo-500 group-hover:text-indigo-500";
+            else if (form.Status == FormStatus.Complete)
+                cssClassFormState = "text-teal-500 group-hover:text-teal-500"; // text-teal-500 group-hover:text-teal-500
+            else if (form.Status == FormStatus.NotIncluded)
+                cssClassFormState = "text-teal-500 group-hover:text-teal-500";
+
+            <a asp-page="/@Model.Version/@form.Kind" asp-route-id="@Model.Id" asp-route-visitKind="@Model.Kind" class="@cssClass group border-l-4 px-3 py-2 flex items-center text-sm font-medium">
+                <span class="@cssClassFormState flex-shrink-0 -ml-1 mr-3 h-6 w-6">@form.Kind</span>
                 <span class="truncate">@form.Title</span>
             </a>
         }

--- a/src/UDS.Net.Forms/Views/_ViewImports.cshtml
+++ b/src/UDS.Net.Forms/Views/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 ﻿@namespace UDS.Net.Forms.Views
 @using UDS.Net.Forms.Models
+@using UDS.Net.Services.Enums
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 

--- a/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
+++ b/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
@@ -14,7 +14,7 @@
 /* Status */
 function setValidationStatus(statusValue, statusText) {
   // get the current form
-  let form = $('form');
+  let form = $('#UDSForm');
 
   // get validator object
   let validator = form.validate();

--- a/src/UDS.Net.Services/DomainModels/Form.cs
+++ b/src/UDS.Net.Services/DomainModels/Form.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UDS.Net.Services.DomainModels.Forms;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Services.DomainModels
 {
@@ -48,13 +49,13 @@ namespace UDS.Net.Services.DomainModels
 
         public string Kind { get; set; }
 
-        public string Status { get; set; }
+        public FormStatus Status { get; set; }
 
-        public string Language { get; set; }
+        public FormLanguage Language { get; set; }
 
-        public bool? IsIncluded { get; set; }
+        public bool? IsIncluded { get; private set; } // Is Included is persisted as Status (Not Included)
 
-        public string ReasonCode { get; set; }
+        public ReasonCode? ReasonCode { get; set; }
 
         public DateTime CreatedAt { get; set; }
 
@@ -115,7 +116,7 @@ namespace UDS.Net.Services.DomainModels
 
             IsRequiredForVisitKind = isRequired;
 
-            Status = "NotStarted"; // TODO change to enum
+            Status = FormStatus.NotStarted;
 
             CreatedBy = createdBy;
 
@@ -125,7 +126,7 @@ namespace UDS.Net.Services.DomainModels
             SetFieldsBasedOnKind();
         }
 
-        public Form(int visitId, int id, string title, string kind, string status, string language, bool? isIncluded, string reasonCode, DateTime createdAt, string createdBy, string modifiedBy, string deletedBy, bool isDeleted, IFormFields fields)
+        public Form(int visitId, int id, string title, string kind, FormStatus status, FormLanguage language, ReasonCode? reasonCode, DateTime createdAt, string createdBy, string modifiedBy, string deletedBy, bool isDeleted, IFormFields fields)
         {
             Id = id;
             VisitId = visitId;
@@ -134,7 +135,7 @@ namespace UDS.Net.Services.DomainModels
             Kind = kind;
             Status = status;
             Language = language;
-            IsIncluded = isIncluded;
+            IsIncluded = !(Status == FormStatus.NotIncluded);
             ReasonCode = reasonCode;
 
             CreatedAt = createdAt;
@@ -149,7 +150,7 @@ namespace UDS.Net.Services.DomainModels
             }
         }
 
-        public Form(int visitId, int id, string title, string kind, bool isRequired, string status, string language, bool? isIncluded, string reasonCode, DateTime createdAt, string createdBy, string modifiedBy, string deletedBy, bool isDeleted, IFormFields fields)
+        public Form(int visitId, int id, string title, string kind, bool isRequired, FormStatus status, FormLanguage language, ReasonCode? reasonCode, DateTime createdAt, string createdBy, string modifiedBy, string deletedBy, bool isDeleted, IFormFields fields)
         {
             Id = id;
             VisitId = visitId;
@@ -159,7 +160,7 @@ namespace UDS.Net.Services.DomainModels
             IsRequiredForVisitKind = isRequired;
             Status = status;
             Language = language;
-            IsIncluded = isIncluded;
+            IsIncluded = !(Status == FormStatus.NotIncluded);
             ReasonCode = reasonCode;
 
             CreatedAt = createdAt;

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -154,7 +154,7 @@ namespace UDS.Net.Services.DomainModels
                     {
                         var existing = existingForms.Where(f => f.Kind == formContract.Abbreviation).FirstOrDefault();
 
-                        Forms.Add(new Form(Id, existing.Id, existing.Title, existing.Kind, formContract.IsRequredForVisitKind, existing.Status, existing.Language, existing.IsIncluded, existing.ReasonCode, existing.CreatedAt, existing.CreatedBy, existing.ModifiedBy, existing.DeletedBy, existing.IsDeleted, existing.Fields));
+                        Forms.Add(new Form(Id, existing.Id, existing.Title, existing.Kind, formContract.IsRequredForVisitKind, existing.Status, existing.Language, existing.ReasonCode, existing.CreatedAt, existing.CreatedBy, existing.ModifiedBy, existing.DeletedBy, existing.IsDeleted, existing.Fields));
                     }
                     else
                     {

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -213,7 +213,7 @@ namespace UDS.Net.Services.DomainModels
         // https://stackoverflow.com/questions/30895888/setting-common-base-class-properties-when-creating-objects
         // TODO Use notifications pattern to return errors and not throwing exceptions
 
-        public bool TryValidate(string formKind)
+        public bool TryValidate()
         {
             // TODO validate the visit against any rules that might have changed due to form fields changing
             GetModelErrors();

--- a/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
@@ -5,6 +5,7 @@ using System.Net.NetworkInformation;
 using UDS.Net.Dto;
 using UDS.Net.Services.DomainModels;
 using UDS.Net.Services.DomainModels.Forms;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Services.Extensions
 {
@@ -16,10 +17,10 @@ namespace UDS.Net.Services.Extensions
             dto.Id = form.Id;
             dto.VisitId = form.VisitId;
             dto.Kind = form.Kind;
-            dto.Status = form.Status;
-            dto.Language = form.Language;
+            dto.Status = ((int)form.Status).ToString();
+            dto.Language = ((int)form.Language).ToString();
             dto.IsIncluded = form.IsIncluded;
-            dto.ReasonCode = form.ReasonCode;
+            dto.ReasonCode = ((int)form.ReasonCode).ToString();
             dto.CreatedAt = form.CreatedAt;
             dto.CreatedBy = form.CreatedBy;
             dto.ModifiedBy = form.ModifiedBy;
@@ -96,16 +97,20 @@ namespace UDS.Net.Services.Extensions
 
         private static FormDto GetDto(Form form)
         {
+            string reasonCode = "";
+            if (form.Status == FormStatus.NotIncluded && form.ReasonCode.HasValue)
+                reasonCode = ((int)form.ReasonCode).ToString();
+
             // set default formDto and then override with more details if it is a strongly typed object
             FormDto dto = new FormDto()
             {
                 Id = form.Id,
                 VisitId = form.VisitId,
                 Kind = form.Kind,
-                Status = form.Status,
-                Language = form.Language,
+                Status = ((int)form.Status).ToString(),
+                Language = ((int)form.Language).ToString(),
                 IsIncluded = form.IsIncluded,
-                ReasonCode = form.ReasonCode,
+                ReasonCode = reasonCode,
                 CreatedAt = form.CreatedAt,
                 CreatedBy = form.CreatedBy,
                 ModifiedBy = form.ModifiedBy,

--- a/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
@@ -20,7 +20,7 @@ namespace UDS.Net.Services.Extensions
             dto.Status = ((int)form.Status).ToString();
             dto.Language = ((int)form.Language).ToString();
             dto.IsIncluded = form.IsIncluded;
-            dto.ReasonCode = ((int)form.ReasonCode).ToString();
+            dto.ReasonCode = form.ReasonCode.HasValue ? ((int)form.ReasonCode.Value).ToString() : "";
             dto.CreatedAt = form.CreatedAt;
             dto.CreatedBy = form.CreatedBy;
             dto.ModifiedBy = form.ModifiedBy;

--- a/src/UDS.Net.Services/Extensions/DtoToDomainMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DtoToDomainMapper.cs
@@ -165,7 +165,24 @@ namespace UDS.Net.Services.Extensions
                 else if (dto.Kind == "T1")
                     title = new T1FormFields().GetDescription();
             }
-            return new Form(visitId, dto.Id, title, dto.Kind, dto.Status, dto.Language, dto.IsIncluded, dto.ReasonCode, dto.CreatedAt, dto.CreatedBy, dto.ModifiedBy, dto.DeletedBy, dto.IsDeleted, formFields);
+
+            FormStatus formStatus = FormStatus.NotStarted;
+            if (!string.IsNullOrWhiteSpace(dto.Status) && Int32.TryParse(dto.Status, out int statusValue))
+            {
+                formStatus = (FormStatus)statusValue;
+            }
+            FormLanguage formLanguage = FormLanguage.English;
+            if (!string.IsNullOrWhiteSpace(dto.Language) && Int32.TryParse(dto.Language, out int languageValue))
+            {
+                formLanguage = (FormLanguage)languageValue;
+            }
+            ReasonCode? reasonCode = null;
+            if (formStatus == FormStatus.NotIncluded && string.IsNullOrWhiteSpace(dto.ReasonCode) && Int32.TryParse(dto.ReasonCode, out int reasonCodeValue))
+            {
+                reasonCode = (ReasonCode)reasonCodeValue;
+            }
+
+            return new Form(visitId, dto.Id, title, dto.Kind, formStatus, formLanguage, reasonCode, dto.CreatedAt, dto.CreatedBy, dto.ModifiedBy, dto.DeletedBy, dto.IsDeleted, formFields);
         }
 
     }

--- a/src/UDS.Net.Web.MVC.Services/VisitService.cs
+++ b/src/UDS.Net.Web.MVC.Services/VisitService.cs
@@ -84,6 +84,12 @@ namespace UDS.Net.Web.MVC.Services
 
         private async Task<Visit> UpdateVisit(string username, VisitDto dto)
         {
+            if (dto.IsDeleted)
+            {
+                dto.DeletedBy = username;
+            }
+            else
+                dto.ModifiedBy = username;
 
             await _apiClient.VisitClient.Put(dto.Id, dto);
 

--- a/src/UDS.Net.Web.MVC/Views/_ViewImports.cshtml
+++ b/src/UDS.Net.Web.MVC/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 ﻿@using UDS.Net.Web.MVC
 @using UDS.Net.Web.MVC.Models
 @using UDS.Net.Forms.Models
+@using UDS.Net.Services.Enums
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 


### PR DESCRIPTION
Fixes #5

## A lot of foundational code changes

- [x] Form statuses are now enums (this affected a large number of the files, but were small changes)
- [x] `Form.IncludeInPacketSubmission` removed because "NotIncluded" is a Status
- [x] `ReasonNotIncluded` removed because it was a duplicate of `ReasonCodeNotIncluded`
- [x] Base `FormModel` view model includes baseline Validation for a form. So, any form inheriting automatically gets validation for basic things (see below)
- [x] A lot of cleanup and simplification taking advantage of inheritance and removal of duplicated code
- [x] We'll use visit data a lot in form model validation so, the Visit Context is given to all base forms during Validate()

## Baseline Validation on a form

- [x] Form status of "NotStarted" displays for any new form, but cannot be saved with this status selected
- [x] A form can always be saved in "In Progress" status. Validation is **not** ran.
- [x] A form can be attempted to be saved in "Complete" status. Validation is ran and error messages are returned if validation doesn't pass.
- [x] A form can only be saved as "NotIncluded" status if the form is _optional_ and if a `ReasonCode` is provided. If a reason code is not provided then the form should display an error message. If the reason code is provided then the form should save.

## UI goodies

- [x] Visit details and sidebar navigation to forms now display different colors to represent statuses.
- [x] Form footer has nicer layout and included inputs required for completion
- [x] Form titles moved to form layout to clean up form views
- [x] Layout included more meta data information (who created it, visit date, etc.)