### PR TITLE
Add the disable functionality

### DIFF
--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -82,6 +82,7 @@ namespace UDS.Net.Forms.Models.UDS3
         public int? LOGIYR { get; set; }
 
         [Display(Name = "Total score from the previous test administration")]
+        [RegularExpression("^(\\d|1\\d|2[0-5]|88)$", ErrorMessage = "(0-25, 88)")]
         [RequiredOnComplete]
         public int? LOGIPREV { get; set; }
 

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -232,7 +232,7 @@ namespace UDS.Net.Forms.Models.UDS3
                                 var visitDate = visitDateEntry;
                                 if (visitDate != null)
                                 {
-                                    if(IsNonApplicableDate(LOGIDAY.Value, LOGIMO.Value, LOGIYR.Value))
+                                    if (IsNonApplicableDate(LOGIDAY.Value, LOGIMO.Value, LOGIYR.Value))
                                     {
                                         isValid = true;
                                     }
@@ -298,7 +298,7 @@ namespace UDS.Net.Forms.Models.UDS3
             int nonApplicableMonth = 88;
             int nonApplicableYear = 8888;
 
-            if(day == nonApplicableDay && month == nonApplicableMonth && year == nonApplicableYear)
+            if (day == nonApplicableDay && month == nonApplicableMonth && year == nonApplicableYear)
             {
                 return true;
             }

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -232,31 +232,38 @@ namespace UDS.Net.Forms.Models.UDS3
                                 var visitDate = visitDateEntry;
                                 if (visitDate != null)
                                 {
-                                    var max = (DateTime)visitDate;
-                                    var min = ((DateTime)visitDate).AddMonths(-3);
-
-                                    try
+                                    if(IsNonApplicableDate(LOGIDAY.Value, LOGIMO.Value, LOGIYR.Value))
                                     {
-                                        var logiDate = new DateTime(LOGIYR.Value, LOGIMO.Value, LOGIDAY.Value);
-
-                                        var resultHigh = DateTime.Compare(logiDate, max);
-                                        var resultLow = DateTime.Compare(logiDate, min);
-
-                                        if (resultHigh < 0 && resultLow > 0)
-                                        {
-                                            isValid = true;
-                                        }
-
-                                        else
-                                        {
-                                            isValid = false;
-                                        }
+                                        isValid = true;
                                     }
-                                    catch (ArgumentOutOfRangeException ex)
+                                    else
                                     {
-                                        // not a valid date
-                                        isValid = false;
-                                        errorMessage = "Logical Memory IA - Immediate previous test date invalid";
+                                        var max = (DateTime)visitDate;
+                                        var min = ((DateTime)visitDate).AddMonths(-3);
+
+                                        try
+                                        {
+                                            var logiDate = new DateTime(LOGIYR.Value, LOGIMO.Value, LOGIDAY.Value);
+
+                                            var resultHigh = DateTime.Compare(logiDate, max);
+                                            var resultLow = DateTime.Compare(logiDate, min);
+
+                                            if (resultHigh < 0 && resultLow > 0)
+                                            {
+                                                isValid = true;
+                                            }
+
+                                            else
+                                            {
+                                                isValid = false;
+                                            }
+                                        }
+                                        catch (ArgumentOutOfRangeException ex)
+                                        {
+                                            // not a valid date
+                                            isValid = false;
+                                            errorMessage = "Logical Memory IA - Immediate previous test date invalid";
+                                        }
                                     }
                                 }
 
@@ -283,6 +290,20 @@ namespace UDS.Net.Forms.Models.UDS3
                 }
             }
             yield break;
+        }
+
+        private static bool IsNonApplicableDate(int day, int month, int year)
+        {
+            int nonApplicableDay = 88;
+            int nonApplicableMonth = 88;
+            int nonApplicableYear = 8888;
+
+            if(day == nonApplicableDay && month == nonApplicableMonth && year == nonApplicableYear)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -10,6 +10,7 @@ namespace UDS.Net.Forms.Models.UDS3
     public class C1 : FormModel
     {
         [Display(Name = "Was any part of the MMSE completed?")]
+        [RequiredOnComplete]
         public int? MMSECOMP { get; set; }
 
         [Display(Name = "No (Enter reason code, 95-98 and SKIP TO QUESTION 2a)")]
@@ -70,18 +71,22 @@ namespace UDS.Net.Forms.Models.UDS3
         public int? LOGIYR { get; set; }
 
         [Display(Name = "Total score from the previous test administration")]
+        [RequiredOnComplete]
         public int? LOGIPREV { get; set; }
 
         [Display(Name = "Total number of story units recalled from this current test administration")]
         [RegularExpression("^(\\d|1\\d|2[0-5]|9[5-8])$", ErrorMessage = "(0-25, 95-98)")]
+        [RequiredOnComplete]
         public int? LOGIMEM { get; set; }
 
         [Display(Name = "Total score for copy of Bension figure")]
         [RegularExpression("^(\\d|1[0-7]|9[5-8])$", ErrorMessage = "(0-17, 95-98)")]
+        [RequiredOnComplete]
         public int? UDSBENTC { get; set; }
 
         [Display(Name = "Total number of trials correct before to two consecutive errors at the same digit length")]
         [RegularExpression("^(\\d|1[0-2]|9[5-8])$", ErrorMessage = "(0-12, 95-98)")]
+        [RequiredOnComplete]
         public int? DIGIF { get; set; }
 
         [Display(Name = "Digit span forward length ")]
@@ -90,6 +95,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Total number of trials correct before to two consecutive errors at the same digit length ")]
         [RegularExpression("^(\\d|1[0-2]|9[5-8])$", ErrorMessage = "(0-12, 95-98)")]
+        [RequiredOnComplete]
         public int? DIGIB { get; set; }
 
         [Display(Name = "Digit span backward length")]
@@ -98,14 +104,17 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Animals: Total number of animals named in 60 seconds")]
         [RegularExpression("^(\\d|[1-6]\\d|7[0-7]|9[5-8])$", ErrorMessage = "(0-77, 95-98)")]
+        [RequiredOnComplete]
         public int? ANIMALS { get; set; }
 
         [Display(Name = "Vegetables: Total number of vegetables named in 60 seconds")]
         [RegularExpression("^(\\d|[1-6]\\d|7[0-7]|9[5-8])$", ErrorMessage = "(0-77, 95-98)")]
+        [RequiredOnComplete]
         public int? VEG { get; set; }
 
         [Display(Name = "PART A: Total number of seconds to complete")]
         [RegularExpression("^(\\d|[1-9]\\d|1[0-4]\\d|150|99[5-8])$", ErrorMessage = "(0-150, 995-998)")]
+        [RequiredOnComplete]
         public int? TRAILA { get; set; }
 
         [Display(Name = "Number of commission errors")]
@@ -118,6 +127,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "PART B: Total number of seconds to complete")]
         [RegularExpression("^(\\d|[1-9]\\d|[12]\\d{2}|300|99[5-8])$", ErrorMessage = "(0-300, 995-998)")]
+        [RequiredOnComplete]
         public int? TRAILB { get; set; }
 
         [Display(Name = "Number of commission errors")]
@@ -130,6 +140,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Total number of story units recalled")]
         [RegularExpression("^(\\d|1\\d|2[0-5]|9[5-8])$", ErrorMessage = "(0-25, 95-98)")]
+        [RequiredOnComplete]
         public int? MEMUNITS { get; set; }
 
         [Display(Name = "Time elapsed since Logical Memory IA–Immediate")]
@@ -138,6 +149,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Total score for 10- to 15-minute delayed drawing of Bension figure")]
         [RegularExpression("^(\\d|1[0-7]|9[5-8])$", ErrorMessage = "(0-17, 95-98)")]
+        [RequiredOnComplete]
         public int? UDSBENTD { get; set; }
 
         [Display(Name = "Recognized original stimulus from among four options?")]
@@ -145,10 +157,12 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Total score")]
         [RegularExpression("^(\\d|[12]\\d|30|9[5-8])$", ErrorMessage = "(0-30, 95-98)")]
+        [RequiredOnComplete]
         public int? BOSTON { get; set; }
 
         [Display(Name = "Number of correct F-words generated in 1 minute")]
         [RegularExpression("^(\\d|[1-3]\\d|40|9[5-8])$", ErrorMessage = "(0-40, 95-98)")]
+        [RequiredOnComplete]
         public int? UDSVERFC { get; set; }
 
         [Display(Name = "Number of F-words repeated in 1 minute")]
@@ -161,6 +175,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Number of correct L-words generated in 1 minute")]
         [RegularExpression("^(\\d|[1-3]\\d|40|9[5-8])$", ErrorMessage = "(0-40, 95-98)")]
+        [RequiredOnComplete]
         public int? UDSVERLC { get; set; }
 
         [Display(Name = "Number of L-words repeated in one minute")]
@@ -184,6 +199,7 @@ namespace UDS.Net.Forms.Models.UDS3
         public int? UDSVERTI { get; set; }
 
         [Display(Name = "Per the clinician (e.g., neuropsychologist, behavioral neurologist, or other suitably qualified clinician), based on the UDS neuropsychological examination, the participant’s cognitive status is deemed")]
+        [RequiredOnComplete]
         public int? COGSTAT { get; set; }
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -15,12 +15,15 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "No (Enter reason code, 95-98 and SKIP TO QUESTION 2a)")]
         [Range(95, 98)]
+        [RequiredIf(nameof(MMSECOMP), "0", ErrorMessage = "Enter reason code")]
         public int? MMSEREAS { get; set; }
 
         [Display(Name = "Administration of the MMSE was")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify administration of the MMSE")]
         public int? MMSELOC { get; set; }
 
         [Display(Name = "Language of MMSE administration")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify language of MMSE administration")]
         public int? MMSELAN { get; set; }
 
         [Display(Name = "Other (specify)")]
@@ -29,31 +32,39 @@ namespace UDS.Net.Forms.Models.UDS3
         public string? MMSELANX { get; set; }
 
         [Display(Name = "Participant was unable to complete one or more sections due to visual impairment")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify a value")]
         public int? MMSEVIS { get; set; }
 
         [Display(Name = "Participant was unable to complete one or more sections due to hearing impairment")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify a value")]
         public int? MMSEHEAR { get; set; }
 
         [Display(Name = "Time")]
         [RegularExpression("^([0-5]|9[5-8])$", ErrorMessage = "(0-5, 95-98)")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify Time")]
         public int? MMSEORDA { get; set; }
 
         [Display(Name = "Place")]
         [RegularExpression("^([0-5]|9[5-8])$", ErrorMessage = "(0-5, 95-98)")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify Place")]
         public int? MMSEORLO { get; set; }
 
         [Display(Name = "Intersecting pentagon subscale score")]
         [RegularExpression("^([0-1]|9[5-8])$", ErrorMessage = "(0-1, 95-98)")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify score")]
         public int? PENTAGON { get; set; }
 
         [Display(Name = "Total MMSE score (using D-L-R-O-W)")]
         [RegularExpression("^(\\d|[12]\\d|30|88)$", ErrorMessage = "(0-30, 88 = Missing)")]
+        [RequiredIf(nameof(MMSECOMP), "1", ErrorMessage = "Specify score")]
         public int? MMSE { get; set; }
 
         [Display(Name = "The remainder of the battery (i.e., the tests summarized below) was administered")]
+        [RequiredOnComplete]
         public int? NPSYCLOC { get; set; }
 
         [Display(Name = "Language of test administration")]
+        [RequiredOnComplete]
         public int? NPSYLAN { get; set; }
 
         [Display(Name = "Other (specify)")]
@@ -91,6 +102,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Digit span forward length ")]
         [Range(0, 8, ErrorMessage = "(0-8)")]
+        [RequiredIfRange(nameof(DIGIF), 0, 12, ErrorMessage = "Specify digit span forward length")]
         public int? DIGIFLEN { get; set; }
 
         [Display(Name = "Total number of trials correct before to two consecutive errors at the same digit length ")]
@@ -100,6 +112,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Digit span backward length")]
         [Range(0, 7, ErrorMessage = "(0-7)")]
+        [RequiredIfRange(nameof(DIGIB), 0, 12, ErrorMessage = "Specify digit span backward length")]
         public int? DIGIBLEN { get; set; }
 
         [Display(Name = "Animals: Total number of animals named in 60 seconds")]
@@ -119,10 +132,12 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Number of commission errors")]
         [Range(0, 40, ErrorMessage = "(0-40)")]
+        [RequiredIfRange(nameof(TRAILA), 0, 150, ErrorMessage = "Specify number of commission errors")]
         public int? TRAILARR { get; set; }
 
         [Display(Name = "Number of correct lines")]
         [Range(0, 24, ErrorMessage = "(0-24)")]
+        [RequiredIfRange(nameof(TRAILA), 0, 150, ErrorMessage = "Specify number of correct lines")]
         public int? TRAILALI { get; set; }
 
         [Display(Name = "PART B: Total number of seconds to complete")]
@@ -132,10 +147,12 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Number of commission errors")]
         [Range(0, 40, ErrorMessage = "(0-40)")]
+        [RequiredIfRange(nameof(TRAILB), 0, 300, ErrorMessage = "Specify number of commission errors")]
         public int? TRAILBRR { get; set; }
 
         [Display(Name = "Number of correct lines")]
         [Range(0, 24, ErrorMessage = "(0-24)")]
+        [RequiredIfRange(nameof(TRAILB), 0, 300, ErrorMessage = "Specify number of correct lines")]
         public int? TRAILBLI { get; set; }
 
         [Display(Name = "Total number of story units recalled")]
@@ -145,6 +162,7 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Time elapsed since Logical Memory IA–Immediate")]
         [RegularExpression("^(\\d|[1-7]\\d|8[0-5]|9[5-8])$", ErrorMessage = "(0-85 minutes, 99 = unknown")]
+        [RequiredIfRange(nameof(MEMUNITS), 0, 25, ErrorMessage = "Specify time elapsed since Logical Memory IA–Immediate")]
         public int? MEMTIME { get; set; }
 
         [Display(Name = "Total score for 10- to 15-minute delayed drawing of Bension figure")]
@@ -153,6 +171,7 @@ namespace UDS.Net.Forms.Models.UDS3
         public int? UDSBENTD { get; set; }
 
         [Display(Name = "Recognized original stimulus from among four options?")]
+        [RequiredIfRange(nameof(UDSBENTD), 0, 17, ErrorMessage = "Specify recognized original stimulus from among four options?\n")]
         public int? UDSBENRS { get; set; }
 
         [Display(Name = "Total score")]
@@ -167,10 +186,12 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Number of F-words repeated in 1 minute")]
         [Range(0, 15, ErrorMessage = "(0-15)")]
+        [RequiredIfRange(nameof(UDSVERFC), 0, 40, ErrorMessage = "Specify number of F-words repeated in 1 minute")]
         public int? UDSVERFN { get; set; }
 
         [Display(Name = "Number of non-F-words and rule violation errors in 1 minute")]
         [Range(0, 15, ErrorMessage = "(0-15)")]
+        [RequiredIfRange(nameof(UDSVERFC), 0, 40, ErrorMessage = "number of non-F-words and rule violation errors in 1 minute")]
         public int? UDSVERNF { get; set; }
 
         [Display(Name = "Number of correct L-words generated in 1 minute")]
@@ -180,22 +201,27 @@ namespace UDS.Net.Forms.Models.UDS3
 
         [Display(Name = "Number of L-words repeated in one minute")]
         [Range(0, 15, ErrorMessage = "(0-15)")]
+        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Specify number of L-words repeated in one minute")]
         public int? UDSVERLR { get; set; }
 
         [Display(Name = "Number of non-L-words and rule violation errors in 1 minute")]
         [Range(0, 15, ErrorMessage = "(0-15)")]
+        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Specify number of non-L-words and rule violation errors in 1 minute")]
         public int? UDSVERLN { get; set; }
 
         [Display(Name = "TOTAL number of correct F-words and L-words")]
         [Range(0, 80, ErrorMessage = "(0-80)")]
+        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Specify total number of correct F-words and L-words")]
         public int? UDSVERTN { get; set; }
 
         [Display(Name = "TOTAL number of F-word and L-word repetition errors")]
         [Range(0, 80, ErrorMessage = "(0-80)")]
+        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Specify total number of F-word and L-word repetition errors")]
         public int? UDSVERTE { get; set; }
 
         [Display(Name = "TOTAL number of non-F/L words and rule violation errors")]
         [Range(0, 80, ErrorMessage = "(0-80)")]
+        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Specify total number of non-F/L words and rule violation errors")]
         public int? UDSVERTI { get; set; }
 
         [Display(Name = "Per the clinician (e.g., neuropsychologist, behavioral neurologist, or other suitably qualified clinician), based on the UDS neuropsychological examination, the participant’s cognitive status is deemed")]

--- a/src/UDS.Net.Forms/Models/UDS3/C1.cs
+++ b/src/UDS.Net.Forms/Models/UDS3/C1.cs
@@ -73,11 +73,11 @@ namespace UDS.Net.Forms.Models.UDS3
         public int? LOGIPREV { get; set; }
 
         [Display(Name = "Total number of story units recalled from this current test administration")]
-        [RegularExpression("^(\\d|1\\d|2[0-5])|(9[5-8])$", ErrorMessage = "(0-25, 95-98)")]
+        [RegularExpression("^(\\d|1\\d|2[0-5]|9[5-8])$", ErrorMessage = "(0-25, 95-98)")]
         public int? LOGIMEM { get; set; }
 
         [Display(Name = "Total score for copy of Bension figure")]
-        [RegularExpression("^(\\d|1[0-7])|(9[5-8])$", ErrorMessage = "(0-17, 95-98)")]
+        [RegularExpression("^(\\d|1[0-7]|9[5-8])$", ErrorMessage = "(0-17, 95-98)")]
         public int? UDSBENTC { get; set; }
 
         [Display(Name = "Total number of trials correct before to two consecutive errors at the same digit length")]
@@ -148,7 +148,7 @@ namespace UDS.Net.Forms.Models.UDS3
         public int? BOSTON { get; set; }
 
         [Display(Name = "Number of correct F-words generated in 1 minute")]
-        [RegularExpression("^(\\d|[1-3]\\d|40]|9[5-8])$", ErrorMessage = "(0-40, 95-98)")]
+        [RegularExpression("^(\\d|[1-3]\\d|40|9[5-8])$", ErrorMessage = "(0-40, 95-98)")]
         public int? UDSVERFC { get; set; }
 
         [Display(Name = "Number of F-words repeated in 1 minute")]

--- a/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
@@ -29,6 +29,7 @@
                         <div class="mt-2">
                             <input asp-for="C1.MMSEREAS" />
                         </div>
+                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.MMSEREAS"></span>
                     </div>
                 </div>
 

--- a/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
@@ -20,7 +20,7 @@
                     <label asp-for="C1.MMSECOMP"><span class="counter"></span> @Html.DisplayNameFor(m => m.C1.MMSECOMP)</label>
                     <div>
                         <p class="text-sm text-gray-500" asp-description-for="C1.MMSECOMP"></p>
-                        <radio-button-group id="@Html.IdFor(m => m.C1.MMSECOMP)" for="@Model.C1.MMSECOMP" items="Model.MMSECompletedListItems"></radio-button-group>
+                        <radio-button-group id="@Html.IdFor(m => m.C1.MMSECOMP)" for="@Model.C1.MMSECOMP" items="Model.MMSECompletedListItems" ui-behaviors="Model.MMSECOMPBehavior"></radio-button-group>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.MMSECOMP"></span>
                     </div>
                     <div>
@@ -46,7 +46,7 @@
                             <label asp-for="C1.MMSELAN"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.C1.MMSELAN)</label>
                             <div>
                                 <p class="text-sm text-gray-500" asp-description-for="C1.MMSELAN"></p>
-                                <radio-button-group id="@Html.IdFor(m => m.C1.MMSELAN)" for="@Model.C1.MMSELAN" items="Model.LanguageListItems"></radio-button-group>
+                                <radio-button-group id="@Html.IdFor(m => m.C1.MMSELAN)" for="@Model.C1.MMSELAN" items="Model.LanguageListItems" ui-behaviors="Model.MMSELANBehavior"></radio-button-group>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.MMSELAN"></span>
                             </div>
                             <div>
@@ -140,7 +140,7 @@
                     <label asp-for="C1.NPSYLAN"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.NPSYLAN)</label>
                     <div>
                         <p class="text-sm text-gray-500" asp-description-for="C1.NPSYLAN"></p>
-                        <radio-button-group id="@Html.IdFor(m => m.C1.NPSYLAN)" for="@Model.C1.NPSYLAN" items="Model.LanguageListItems"></radio-button-group>
+                        <radio-button-group id="@Html.IdFor(m => m.C1.NPSYLAN)" for="@Model.C1.NPSYLAN" items="Model.LanguageListItems" ui-behaviors="Model.NPSYLANBehavior"></radio-button-group>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.NPSYLAN"></span>
                     </div>
                     <div>
@@ -219,7 +219,7 @@
                     <label asp-for="C1.DIGIF"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.DIGIF)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.DIGIF"></p>
-                        <input asp-for="@Model.C1.DIGIF" />
+                        <input asp-for="@Model.C1.DIGIF" ui-range-behavior="Model.DIGIFBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.DIGIF"></span>
                     </div>
                 </div>
@@ -241,7 +241,7 @@
                     <label asp-for="C1.DIGIB"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.DIGIB)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.DIGIB"></p>
-                        <input asp-for="@Model.C1.DIGIB" />
+                        <input asp-for="@Model.C1.DIGIB" ui-range-behavior="Model.DIGIBBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.DIGIB"></span>
                     </div>
                 </div>
@@ -288,7 +288,7 @@
                     <label asp-for="C1.TRAILA"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.TRAILA)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.TRAILA"></p>
-                        <input asp-for="@Model.C1.TRAILA" />
+                        <input asp-for="@Model.C1.TRAILA" ui-range-behavior="Model.TRAILABehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.TRAILA"></span>
                     </div>
                 </div>
@@ -316,7 +316,7 @@
                     <label asp-for="C1.TRAILB"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.TRAILB)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.TRAILB"></p>
-                        <input asp-for="@Model.C1.TRAILB" />
+                        <input asp-for="@Model.C1.TRAILB" ui-range-behavior="Model.TRAILBBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.TRAILB"></span>
                     </div>
                 </div>
@@ -349,7 +349,7 @@
                     <label asp-for="C1.MEMUNITS"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.MEMUNITS)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.MEMUNITS"></p>
-                        <input asp-for="@Model.C1.MEMUNITS" />
+                        <input asp-for="@Model.C1.MEMUNITS" ui-range-behavior="Model.MEMUNITSBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.MEMUNITS"></span>
                     </div>
                 </div>
@@ -372,7 +372,7 @@
                     <label asp-for="C1.UDSBENTD"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.UDSBENTD)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.UDSBENTD"></p>
-                        <input asp-for="@Model.C1.UDSBENTD" />
+                        <input asp-for="@Model.C1.UDSBENTD" ui-range-behavior="Model.UDSBENTDBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.UDSBENTD"></span>
                     </div>
                 </div>
@@ -410,7 +410,7 @@
                     <label asp-for="C1.UDSVERFC"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.UDSVERFC)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.UDSVERFC"></p>
-                        <input asp-for="@Model.C1.UDSVERFC" />
+                        <input asp-for="@Model.C1.UDSVERFC" ui-range-behavior="Model.UDSVERFCBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.UDSVERFC"></span>
                     </div>
                 </div>
@@ -437,7 +437,7 @@
                     <label asp-for="C1.UDSVERLC"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C1.UDSVERLC)</label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.C1.UDSVERLC"></p>
-                        <input asp-for="@Model.C1.UDSVERLC" />
+                        <input asp-for="@Model.C1.UDSVERLC" ui-range-behavior="Model.UDSVERLCBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.UDSVERLC"></span>
                     </div>
                 </div>

--- a/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml
@@ -55,6 +55,7 @@
                                 <label asp-for="C1.MMSELANX">@Html.DisplayNameFor(m => m.C1.MMSELANX)</label>
                                 <div class="mt-2">
                                     <input asp-for="C1.MMSELANX" />
+                                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.MMSELANX"></span>
                                 </div>
                             </div>
                         </div>
@@ -149,6 +150,7 @@
                         <label asp-for="C1.NPSYLANX">@Html.DisplayNameFor(m => m.C1.NPSYLANX)</label>
                         <div class="mt-2">
                             <input asp-for="C1.NPSYLANX" />
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C1.NPSYLANX"></span>
                         </div>
                     </div>
                 </div>

--- a/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS3/C1.cshtml.cs
@@ -53,6 +53,175 @@ namespace UDS.Net.Forms.Pages.UDS3
             new RadioListItem("Clinician unable to render opinion", "0")
         };
 
+        public Dictionary<string, UIBehavior> MMSECOMPBehavior = new Dictionary<string, UIBehavior>
+        {
+            { "0", new UIBehavior {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.MMSEREAS"),
+                    new UIDisableAttribute("C1.MMSELOC"),
+                    new UIDisableAttribute("C1.MMSELAN"),
+                    new UIDisableAttribute("C1.MMSELANX"),
+                    new UIDisableAttribute("C1.MMSEVIS"),
+                    new UIDisableAttribute("C1.MMSEHEAR"),
+                    new UIDisableAttribute("C1.MMSEORDA"),
+                    new UIDisableAttribute("C1.MMSEORLO"),
+                    new UIDisableAttribute("C1.PENTAGON"),
+                    new UIDisableAttribute("C1.MMSE")
+                },
+                InstructionalMessage = "skip to question 2a"
+            } },
+            { "1", new UIBehavior {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIDisableAttribute("C1.MMSEREAS"),
+                    new UIEnableAttribute("C1.MMSELOC"),
+                    new UIEnableAttribute("C1.MMSELAN"),
+                    new UIEnableAttribute("C1.MMSELANX"),
+                    new UIEnableAttribute("C1.MMSEVIS"),
+                    new UIEnableAttribute("C1.MMSEHEAR"),
+                    new UIEnableAttribute("C1.MMSEORDA"),
+                    new UIEnableAttribute("C1.MMSEORLO"),
+                    new UIEnableAttribute("C1.PENTAGON"),
+                    new UIEnableAttribute("C1.MMSE")
+                },
+                InstructionalMessage = "continue to question 1b"
+            } }
+        };
+
+        public Dictionary<string, UIBehavior> MMSELANBehavior = new Dictionary<string, UIBehavior>
+        {
+            { "1", new UIBehavior { PropertyAttribute = new UIDisableAttribute("C1.MMSELANX")} },
+            { "2", new UIBehavior { PropertyAttribute = new UIDisableAttribute("C1.MMSELANX")} },
+            { "3", new UIBehavior { PropertyAttribute = new UIEnableAttribute("C1.MMSELANX")} }
+        };
+
+        public Dictionary<string, UIBehavior> NPSYLANBehavior = new Dictionary<string, UIBehavior>
+        {
+            { "1", new UIBehavior { PropertyAttribute = new UIDisableAttribute("C1.NPSYLANX")} },
+            { "2", new UIBehavior { PropertyAttribute = new UIDisableAttribute("C1.NPSYLANX")} },
+            { "3", new UIBehavior { PropertyAttribute = new UIEnableAttribute("C1.NPSYLANX")} }
+        };
+
+        public UIRangeToggle DIGIFBehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 12,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.DIGIFLEN"),
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 95-98, and skip to question 6a."
+            }
+        };
+
+        public UIRangeToggle DIGIBBehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 12,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.DIGIBLEN"),
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 95-98, and skip to question 7a."
+            }
+        };
+
+        public UIRangeToggle TRAILABehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 150,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.TRAILARR"),
+                    new UIEnableAttribute("C1.TRAILALI")
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 995-998, and skip to question 8b."
+            }
+        };
+
+        public UIRangeToggle TRAILBBehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 300,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.TRAILBRR"),
+                    new UIEnableAttribute("C1.TRAILBLI")
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 995-998, and skip to question 9a."
+            }
+        };
+
+        public UIRangeToggle MEMUNITSBehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 25,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.MEMTIME")
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 95-98, and skip to question 10a."
+            }
+        };
+
+        public UIRangeToggle UDSBENTDBehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 17,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.UDSBENRS")
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 95-98, and skip to question 11a."
+            }
+        };
+
+        public UIRangeToggle UDSVERFCBehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 40,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.UDSVERFN"),
+                    new UIEnableAttribute("C1.UDSVERNF")
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 95-98, and skip to question 12d."
+            }
+        };
+
+        public UIRangeToggle UDSVERLCBehavior = new UIRangeToggle
+        {
+            Low = 0,
+            High = 40,
+            UIBehavior = new UIBehavior
+            {
+                PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("C1.UDSVERLR"),
+                    new UIEnableAttribute("C1.UDSVERLN"),
+                    new UIEnableAttribute("C1.UDSVERTN"),
+                    new UIEnableAttribute("C1.UDSVERTE"),
+                    new UIEnableAttribute("C1.UDSVERTI")
+                },
+                InstructionalMessage = "if test not completed, enter reason code, 95-98, and skip to question 13a."
+            }
+        };
+
         public C1Model(IVisitService visitService) : base(visitService, "C1")
         {
         }


### PR DESCRIPTION
Resolves: #83 

### List of changes and additions made to the C1 functionality
- [ ] Validation message added to question 1 other field
- [ ] No validation message for 1a1 other field when error, just the red outline
- [ ] 2b other field does not display error message
- [ ] 3a cannot be completed with an input of 88/88/8888 (unknown), but it CAN be partial saved. CAN be accepted on a valid date for completion
- [ ] 3a1 does not follow validation range of the pdf guide (0 - 25) all values are accepted
- [ ] 3b validation is checking the wrong range, won't accept 10 or 20
- [ ] 4a not accepting 10 on its 0-17 range (it accepts 1)
- [ ] 12a not accepting input of 40
- [ ] Question 8b does not save when submitted
- [ ] Add in required if range for optional inputs

### Reviewing the form
The form is pretty straightforward to follow. Optional inputs are required after being enabled, all parent inputs are required to have values on completion. Range inputs enable child fields within valid range. Following the error messages after trying to complete a blank form should give you a roadmap for checking. 

### Required for testing
You will need to run the web PR alongside this PR here: UK-SBCoA/uniform-data-set-dotnet-api#19