### PR TITLE
Dockerhub workflow test

### DIFF
--- a/.github/workflows/push-image-to-dockerhub.yml
+++ b/.github/workflows/push-image-to-dockerhub.yml
@@ -11,7 +11,7 @@ name: Push image to DockerHub
 
 on:
   push:
-    branches: ['release']
+    branches: ['dockerhub-workflow-test']
 
 jobs:
   push_to_registry:

--- a/.github/workflows/push-image-to-dockerhub.yml
+++ b/.github/workflows/push-image-to-dockerhub.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
-          context: .
-          file: ./Dockerfile
+          context: src/
+          file: src/UDS.Net.Web.MVC/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push-image-to-dockerhub.yml
+++ b/.github/workflows/push-image-to-dockerhub.yml
@@ -11,7 +11,7 @@ name: Push image to DockerHub
 
 on:
   push:
-    branches: ['dockerhub-workflow-test']
+    branches: ['release']
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
Fixes: #88

## Create a Github action to push a docker image to dockerHub on a release branch push. 

The tag of the dockerHub image is based on the branch the workflow is running on. When this branch is merged into release, there will be a new dockerHub image pushed with the tag of `release`

The current dockerHub image is `uniform-data-set-dotnet-web:dockerhub-workflow-test` and will be removed from dockerHub post approval of this card, as it is outdated and exists as evidence of the successful workflow run for review.

you can review the current image in dockerHub [here](https://hub.docker.com/layers/uksbcoa/uniform-data-set-dotnet-web/dockerhub-workflow-test/images/sha256-f4a7f3cda5f869c5b50cbb163e7249ce014fc882c2246962ee79f77ddccc10e1?context=repo
)
