### PR TITLE
Add pagination to participations

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>2.0.7</ReleaseVersion>
+		<ReleaseVersion>2.0.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />

--- a/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
@@ -25,6 +25,18 @@ namespace UDS.Net.Forms.Extensions
             vm.IsDeleted = form.IsDeleted;
         }
 
+        public static ParticipationsPaginatedModel ToVM(this IEnumerable<Participation> participations, int pageSize, int pageIndex, int total, string search)
+        {
+            return new ParticipationsPaginatedModel
+            {
+                List = participations.Select(p => p.ToVM()).ToList(),
+                PageSize = pageSize,
+                PageIndex = pageIndex,
+                Total = total,
+                Search = search
+            };
+        }
+
         public static ParticipationModel ToVM(this Participation participation)
         {
             return new ParticipationModel()

--- a/src/UDS.Net.Forms/Models/PaginatedModel.cs
+++ b/src/UDS.Net.Forms/Models/PaginatedModel.cs
@@ -1,0 +1,58 @@
+﻿using System;
+namespace UDS.Net.Forms.Models
+{
+    public class PaginatedModel
+    {
+        public bool HasPreviousPage
+        {
+            get
+            {
+                return (PageIndex > 1);
+            }
+        }
+        public bool HasNextPage
+        {
+            get
+            {
+                return (PageIndex < TotalPages);
+            }
+        }
+        public int PageSize { get; set; } = 10;
+        public int PageIndex { get; set; } = 1;
+        public int Total { get; set; } = 0;
+        public int TotalPages
+        {
+            get
+            {
+                if (Total > 0)
+                    return (int)Math.Ceiling(Total / (double)PageSize);
+
+                return 0;
+            }
+        }
+        public int CurrentPageStart
+        {
+            get
+            {
+                return ((PageIndex - 1) * PageSize) + 1;
+            }
+        }
+        public int CurrentPageEnd
+        {
+            get
+            {
+                if (HasNextPage)
+                {
+                    return CurrentPageStart + PageSize - 1;
+                }
+                else
+                    return Total;
+            }
+        }
+
+        public string Search { get; set; }
+        public string Action { get; set; } = "Index";
+        public int? Id { get; set; } = null; // sometimes the paginated list is a child of the current object, do we might need an id
+    }
+}
+

--- a/src/UDS.Net.Forms/Models/ParticipationsPaginatedModel.cs
+++ b/src/UDS.Net.Forms/Models/ParticipationsPaginatedModel.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace UDS.Net.Forms.Models
+{
+    public class ParticipationsPaginatedModel : PaginatedModel
+    {
+        public List<ParticipationModel> List { get; set; } = new List<ParticipationModel>();
+    }
+}
+

--- a/src/UDS.Net.Forms/Pages/Participations/Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/Participations/Index.cshtml
@@ -37,7 +37,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var participation in Model.Participations)
+                            @foreach (var participation in Model.Participations.List)
                             {
                                 <tr>
                                     <td>@participation.Id</td>
@@ -48,6 +48,9 @@
                             }
                         </tbody>
                     </table>
+                </div>
+                <div class="py-4">
+                    <partial name="_PreviousNextButtons" model="Model.Participations" />
                 </div>
             </div>
         </div>

--- a/src/UDS.Net.Forms/Pages/Participations/Index.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/Participations/Index.cshtml.cs
@@ -14,18 +14,20 @@ namespace UDS.Net.Forms.Pages.Participations
     {
         private readonly IParticipationService _participationService;
 
-        public IList<ParticipationModel>? Participations { get; set; }
+        public ParticipationsPaginatedModel Participations { get; set; } = new ParticipationsPaginatedModel();
 
         public IndexModel(IParticipationService participationService)
         {
             _participationService = participationService;
         }
 
-        public async Task<IActionResult> OnGet()
+        public async Task<IActionResult> OnGet(int pageSize = 10, int pageIndex = 1, string search = "")
         {
-            var participations = await _participationService.List("");
+            var participations = await _participationService.List(User.Identity.Name, pageSize, pageIndex);
 
-            Participations = participations.Select(p => p.ToVM()).ToList();
+            int total = await _participationService.Count(User.Identity.Name);
+
+            Participations = participations.ToVM(pageSize, pageIndex, total, search);
 
             return Page();
         }

--- a/src/UDS.Net.Forms/Pages/Shared/_PreviousNextButtons.cshtml
+++ b/src/UDS.Net.Forms/Pages/Shared/_PreviousNextButtons.cshtml
@@ -1,0 +1,59 @@
+﻿@model PaginatedModel
+@{
+    var buttonCSS = "relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:outline-offset-0";
+    var disabledCSS = "relative inline-flex items-center rounded-md bg-slate-50 px-3 py-2 text-sm font-semibold text-gray-500 ring-1 ring-inset ring-gray-300 focus-visible:outline-offset-0";
+}
+
+<nav class="flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 sm:px-6" aria-label="Pagination">
+    <div class="hidden sm:block">
+        <p class="text-sm text-gray-700">
+            Showing
+            <span class="font-medium">@Model.CurrentPageStart</span>
+            to
+            <span class="font-medium">@Model.CurrentPageEnd</span>
+            of
+            <span class="font-medium">@Model.Total</span>
+            results
+        </p>
+    </div>
+    <div class="flex flex-1 justify-between sm:justify-end">
+        @if (Model.HasPreviousPage)
+        {
+            @if (Model.Id.HasValue)
+            {
+                <a asp-page="@Model.Action" asp-route-id="@Model.Id.Value" asp-route-pageIndex="@(Model.PageIndex - 1)"
+                   asp-route-search="@Model.Search"
+                   class="@buttonCSS">Previous</a>
+            }
+            else
+            {
+                <a asp-page="@Model.Action" asp-route-pageIndex="@(Model.PageIndex - 1)"
+                   asp-route-search="@Model.Search"
+                   class="@buttonCSS">Previous</a>
+            }
+        }
+        else
+        {
+            <a disabled class="@disabledCSS">Previous</a>
+        }
+        @if (Model.HasNextPage)
+        {
+            @if (Model.Id.HasValue)
+            {
+                <a asp-page="@Model.Action" asp-route-id="@Model.Id.Value" asp-route-pageIndex="@(Model.PageIndex + 1)"
+                   asp-route-search="@Model.Search"
+                   class="ml-3 @buttonCSS">Next</a>
+            }
+            else
+            {
+                <a asp-page="@Model.Action" asp-route-pageIndex="@(Model.PageIndex + 1)"
+                   asp-route-search="@Model.Search"
+                   class="ml-3 @buttonCSS">Next</a>
+            }
+        }
+        else
+        {
+            <a disabled class="ml-3 @disabledCSS">Next</a>
+        }
+    </div>
+</nav>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>2.0.7</Version>
+		<Version>2.0.8</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>2.0.7</ReleaseVersion>
+		<ReleaseVersion>2.0.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>2.0.7</ReleaseVersion>
+    <ReleaseVersion>2.0.8</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>2.0.7</Version>
+		<Version>2.0.8</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>2.0.7</ReleaseVersion>
+		<ReleaseVersion>2.0.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="2.0.1" />

--- a/src/UDS.Net.Web.MVC.Services/ParticipationService.cs
+++ b/src/UDS.Net.Web.MVC.Services/ParticipationService.cs
@@ -65,7 +65,7 @@ namespace UDS.Net.Web.MVC.Services
 
         public async Task<IEnumerable<Participation>> List(string username, int pageSize = 10, int pageIndex = 1)
         {
-            var participationDtos = await _apiClient.ParticipationClient.Get();
+            var participationDtos = await _apiClient.ParticipationClient.Get(pageSize, pageIndex);
 
             if (participationDtos != null)
             {

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>2.0.7</Version>
+		<Version>2.0.8</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>2.0.7</ReleaseVersion>
+		<ReleaseVersion>2.0.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="7.0.3" />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>2.0.7</ReleaseVersion>
+		<ReleaseVersion>2.0.8</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -15,7 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{395296FB-4036-4FC9-A8DC-A50F96D35623}"
 EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{3E95F6CB-54A2-401F-BB86-080CD89308F8}"
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{D137052A-E67B-4C5B-88A6-90D37D90653C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,10 +47,10 @@ Global
 		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3E95F6CB-54A2-401F-BB86-080CD89308F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3E95F6CB-54A2-401F-BB86-080CD89308F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3E95F6CB-54A2-401F-BB86-080CD89308F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3E95F6CB-54A2-401F-BB86-080CD89308F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D137052A-E67B-4C5B-88A6-90D37D90653C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D137052A-E67B-4C5B-88A6-90D37D90653C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D137052A-E67B-4C5B-88A6-90D37D90653C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D137052A-E67B-4C5B-88A6-90D37D90653C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 2.0.3
+		version = 2.0.8
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- [x] You'll need to add more than 10 participation records to your local dev env in order to test
- [x] Paginates participations table in page sizes of 10
- [x] Clicking "Next" button goes to the next page
- [x] Clicking "Previous" button goes to the previous page
- [x] If there is no previous or next page available then the button is disabled
- [x] Pagination area shows calculation of current record indices for the current page including overall total

![Screen Shot 2024-03-20 at 1 21 21 PM](https://github.com/UK-SBCoA/uniform-data-set-dotnet-web/assets/91937/88d37b9c-33b5-4428-8a71-7607295f3421)
