### PR TITLE
Additional a1 validation

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.6.6</ReleaseVersion>
+		<ReleaseVersion>4.6.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -379,7 +379,32 @@ namespace UDS.Net.Forms.Models.UDS4
                 else return null;
             }
         }
-
+        [RequiredOnFinalized(ErrorMessage = "If response 4f is checked then responses 4h and 4i must be blank")]
+        [NotMapped]
+        public bool? TwoSpiritGender
+        {
+            get
+            {
+                if (GENTWOSPIR == true && (GENDKN == true || GENNOANS == true))
+                {
+                    return null;
+                }
+                else return true;
+            }
+        }
+        [RequiredOnFinalized(ErrorMessage = "If response 7a is checked then responses 7f and 7g must be blank")]
+        [NotMapped]
+        public bool? TwoSpiritSexOrientation
+        {
+            get
+            {
+                if (SEXORNTWOS == true && (SEXORNDNK == true || GENNOANS == SEXORNNOAN))
+                {
+                    return null;
+                }
+                else return true;
+            }
+        }
         [Display(Name = "What is your primary language?")]
         [RequiredOnFinalized]
         public int? PREDOMLAN { get; set; }

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -431,6 +431,20 @@ namespace UDS.Net.Forms.Models.UDS4
                 else return true;
             }
         }
+
+        [RequiredOnFinalized(ErrorMessage = "If question 16 ('MEDVA') is marked as 'Yes' then question 15 ('SERVED') cannot equal 'Don't Know'")]
+        [NotMapped]
+        public bool? VAMedCare
+        {
+            get
+            {
+                if (MEDVA == 1 && SERVED == 9)
+                {
+                    return null;
+                }
+                else return true;
+            }
+        }
         [Display(Name = "What is your primary language?")]
         [RequiredOnFinalized]
         public int? PREDOMLAN { get; set; }

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -364,6 +364,22 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
+        [RequiredOnFinalized(ErrorMessage = "Both question 15(A1.SERVED) and 16(A1.MEDVA) cannot have a value of \"Don't Know\"")]
+        [NotMapped]
+        public bool? ServedAndVaCare
+        {
+            get
+            {
+                if (SERVED == 9 && MEDVA != 9 ||
+                    SERVED == 1 && (MEDVA == 9 || MEDVA == 1 || MEDVA == 0) ||
+                    SERVED == 0 && MEDVA == null)
+                {
+                    return true;
+                }
+                else return null;
+            }
+        }
+
         [Display(Name = "What is your primary language?")]
         [RequiredOnFinalized]
         public int? PREDOMLAN { get; set; }

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -405,32 +405,6 @@ namespace UDS.Net.Forms.Models.UDS4
                 else return true;
             }
         }
-        [RequiredOnFinalized(ErrorMessage = "GENOTHX must be blank when response 4g. is unchecked")]
-        [NotMapped]
-        public bool? GenderSpecify
-        {
-            get
-            {
-                if (!string.IsNullOrWhiteSpace(GENOTHX) && GENOTH == false)
-                {
-                    return null;
-                }
-                else return true;
-            }
-        }
-        [RequiredOnFinalized(ErrorMessage = "SEXORNOTHX must be blank when response 7e. is unchecked")]
-        [NotMapped]
-        public bool? SexOrientationSpecify
-        {
-            get
-            {
-                if (!string.IsNullOrWhiteSpace(SEXORNOTHX) && SEXORNOTH == false)
-                {
-                    return null;
-                }
-                else return true;
-            }
-        }
 
         [RequiredOnFinalized(ErrorMessage = "If question 16 ('MEDVA') is marked as 'Yes' then question 15 ('SERVED') cannot equal 'Don't Know'")]
         [NotMapped]

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -364,21 +364,23 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
-        [RequiredOnFinalized(ErrorMessage = "Both question 15(A1.SERVED) and 16(A1.MEDVA) cannot have a value of \"Don't Know\"")]
+        [RequiredOnFinalized(ErrorMessage = "If Q16. MEDVA (VA medical care) = 1 (Yes) then Q15. SERVED (served in armed forces) should not equal 9 (Don't know),it should be equal to 1 (Yes)")]
         [NotMapped]
         public bool? ServedAndVaCare
         {
             get
             {
-                if (SERVED == 9 && MEDVA != 9 ||
-                    SERVED == 1 && (MEDVA == 9 || MEDVA == 1 || MEDVA == 0) ||
-                    SERVED == 0 && MEDVA == null)
+                if (SERVED == 9)
                 {
-                    return true;
-                }
-                else return null;
+                    if (MEDVA == 1)
+                    {
+                        return null;
+                    }
+                }    
+                return true;
             }
         }
+
         [RequiredOnFinalized(ErrorMessage = "If response 4f is checked then responses 4h and 4i must be blank")]
         [NotMapped]
         public bool? TwoSpiritGender
@@ -406,19 +408,6 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
-        [RequiredOnFinalized(ErrorMessage = "If question 16 ('MEDVA') is marked as 'Yes' then question 15 ('SERVED') cannot equal 'Don't Know'")]
-        [NotMapped]
-        public bool? VAMedCare
-        {
-            get
-            {
-                if (MEDVA == 1 && SERVED == 9)
-                {
-                    return null;
-                }
-                else return true;
-            }
-        }
         [Display(Name = "What is your primary language?")]
         [RequiredOnFinalized]
         public int? PREDOMLAN { get; set; }

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -394,7 +394,7 @@ namespace UDS.Net.Forms.Models.UDS4
                 else return true;
             }
         }
-        [RequiredOnFinalized(ErrorMessage = "If response 7a is checked then responses 7f and 7g must be blank")]
+        [RequiredOnFinalized(ErrorMessage = "If response 7d is checked then responses 7f and 7g must be blank")]
         [NotMapped]
         public bool? TwoSpiritSexOrientation
         {

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -405,6 +405,32 @@ namespace UDS.Net.Forms.Models.UDS4
                 else return true;
             }
         }
+        [RequiredOnFinalized(ErrorMessage = "GENOTHX must be blank when response 4g. is unchecked")]
+        [NotMapped]
+        public bool? GenderSpecify
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(GENOTHX) && GENOTH == false)
+                {
+                    return null;
+                }
+                else return true;
+            }
+        }
+        [RequiredOnFinalized(ErrorMessage = "SEXORNOTHX must be blank when response 7e. is unchecked")]
+        [NotMapped]
+        public bool? SexOrientationSpecify
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(SEXORNOTHX) && SEXORNOTH == false)
+                {
+                    return null;
+                }
+                else return true;
+            }
+        }
         [Display(Name = "What is your primary language?")]
         [RequiredOnFinalized]
         public int? PREDOMLAN { get; set; }

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -376,7 +376,7 @@ namespace UDS.Net.Forms.Models.UDS4
                     {
                         return null;
                     }
-                }    
+                }
                 return true;
             }
         }

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -398,7 +398,7 @@ namespace UDS.Net.Forms.Models.UDS4
         {
             get
             {
-                if (SEXORNTWOS == true && (SEXORNDNK == true || GENNOANS == SEXORNNOAN))
+                if (SEXORNTWOS == true && (SEXORNDNK == true || SEXORNNOAN == true))
                 {
                     return null;
                 }

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -408,6 +408,33 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
+        [RequiredOnFinalized(ErrorMessage = "GENOTHX must be blank when response 4g. is unchecked")]
+        [NotMapped]
+        public bool? GenderSpecify
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(GENOTHX) && GENOTH == false)
+                {
+                    return null;
+                }
+                else return true;
+            }
+        }
+        [RequiredOnFinalized(ErrorMessage = "SEXORNOTHX must be blank when response 7e. is unchecked")]
+        [NotMapped]
+        public bool? SexOrientationSpecify
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(SEXORNOTHX) && SEXORNOTH == false)
+                {
+                    return null;
+                }
+                else return true;
+            }
+        }
+
         [Display(Name = "What is your primary language?")]
         [RequiredOnFinalized]
         public int? PREDOMLAN { get; set; }

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -657,6 +657,8 @@
             <div>
                 <label class="text-base font-semibold text-gray-900"><span class="counter"></span>Which term(s) best describes your current gender identity? (Check all that apply)</label><br />
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.GenderIdentityIndicated"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.TwoSpiritGender"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.TwoSpiritSexOrientation"></span>
             </div>
             <div class="mt-4 sm:col-span-2 sm:mt-0">
                 <fieldset class="subcounterreset">
@@ -793,6 +795,7 @@
             <div>
                 <label class="text-base font-semibold text-gray-900"><span class="counter"></span>Which term(s) best describes your sexual orientation? (Check all that apply)</label><br />
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.SexualOrientstionIndicated"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.TwoSpiritSexOrientation"></span>
             </div>
             <div class="mt-4 sm:col-span-2 sm:mt-0">
                 <fieldset class="subcounterreset">
@@ -871,7 +874,9 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.SEXORNNOAN", Model.A1.SEXORNNOAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
+                                @Html.CheckBox("A1.SEXORNNOAN", Model.A1.SEXORNNOAN, new
+                                {
+                                    @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                 data_checkBoxDisable_target = "checkboxTrigger",
                                 data_action = "input->checkboxDisable#ToggleGroup",
 
@@ -984,6 +989,7 @@
                 <p class="text-sm text-gray-500" asp-description-for="@Model.A1.SERVED"></p>
                 <radio-button-group id="@Html.IdFor(m => m.A1.SERVED)" for="@Model.A1.SERVED" items="Model.SERVEDListItems" ui-behaviors="Model.SERVEDUIBehavior"></radio-button-group>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.SERVED"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.ServedAndVaCare"></span>
             </div>
         </div>
 
@@ -993,6 +999,7 @@
                 <p class="text-sm text-gray-500" asp-description-for="@Model.A1.MEDVA"></p>
                 <radio-button-group id="@Html.IdFor(m => m.A1.MEDVA)" for="@Model.A1.MEDVA" items="Model.MEDVAListItems"></radio-button-group>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.MEDVA"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.ServedAndVaCare"></span>
             </div>
         </div>
 

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -721,7 +721,16 @@
                             <div class="relative flex items-start">
                                 <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                                 <div class="flex h-6 items-center">
-                                    @Html.CheckBox("A1.GENOTH", Model.A1.GENOTH, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", data_affects = "true", data_affects_toggle_targets = "[ \"A1.GENOTHX\" ]" })
+                                    <!--// GENOTH is pretty complex because it needs to enable and also disable //-->
+                                    @Html.CheckBox("A1.GENOTH", Model.A1.GENOTH, new
+                                    {
+                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
+                                        data_checkBoxDisable_target = "checkboxTrigger",
+                                        data_action = "input->checkboxDisable#ToggleGroup",
+                                        data_checkBoxDisable_enableGroup_param = "A1.GENOTHX",
+                                        data_checkBoxDisable_disableGroup_param = "A1.GENDKN,A1.GENNOANS",
+                                        data_checkboxDisable_toggleState_param = "true"
+                                    })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.GENOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENOTH)</label>
@@ -744,8 +753,9 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENNOANS",
-                                        data_checkboxDisable_disable_param = "true"
+                                        data_checkBoxDisable_enableGroup_param = "",
+                                        data_checkBoxDisable_disableGroup_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENNOANS",
+                                        data_checkboxDisable_toggleState_param = "true"
                                     })
                             </div>
                             <div class="ml-3 text-sm leading-6">
@@ -760,8 +770,9 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN,A1.GENOTH",
-                                        data_checkboxDisable_disable_param = "true"
+                                        data_checkBoxDisable_enableGroup_param = "",
+                                        data_checkBoxDisable_disableGroup_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN,A1.GENOTH",
+                                        data_checkboxDisable_toggleState_param = "true"
                                     })
                             </div>
                             <div class="ml-3 text-sm leading-6">
@@ -863,8 +874,9 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNOTHX",
-                                        data_checkboxDisable_disable_param = "true"
+                                        data_checkBoxDisable_enableGroup_param = "",
+                                        data_checkBoxDisable_disableGroup_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNOTHX",
+                                        data_checkboxDisable_toggleState_param = "true"
                                     })
                             </div>
                             <div class="ml-3 text-sm leading-6">
@@ -877,11 +889,11 @@
                                 @Html.CheckBox("A1.SEXORNNOAN", Model.A1.SEXORNNOAN, new
                                 {
                                     @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
-                                data_checkBoxDisable_target = "checkboxTrigger",
-                                data_action = "input->checkboxDisable#ToggleGroup",
-
-                                        data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNDNK,A1.SEXORNOTHX",
-                                        data_checkboxDisable_disable_param = "true"
+                                    data_checkBoxDisable_target = "checkboxTrigger",
+                                    data_action = "input->checkboxDisable#ToggleGroup",
+                                    data_checkBoxDisable_enableGroup_param = "",
+                                    data_checkBoxDisable_disableGroup_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNDNK,A1.SEXORNOTHX",
+                                    data_checkboxDisable_toggleState_param = "true"
                                 })
                             </div>
                             <div class="ml-3 text-sm leading-6">

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -725,13 +725,13 @@
                                     @Html.CheckBox("A1.GENOTH", Model.A1.GENOTH, new
                                     {
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
-                                        data_affects = "true", data_affects_toggle_targets = "[ \"A1.GENOTHX\"]",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
                                         data_checkBoxDisable_enableGroup_param = "A1.GENOTHX",
                                         data_checkBoxDisable_disableGroup_param = "A1.GENDKN,A1.GENNOANS",
-                                        data_checkboxDisable_toggleState_param = "true"
-                                    })
+                                        data_checkboxDisable_toggleState_param = "true",
+                                        data_checkboxDisable_disableOnLoad_param = "A1.GENOTHX"
+                                        })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.GENOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENOTH)</label>
@@ -855,14 +855,13 @@
                                     @Html.CheckBox("A1.SEXORNOTH", Model.A1.SEXORNOTH, new 
                                     { 
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
-                                        data_affects = "true", data_affects_toggle_targets = "[ \"A1.SEXORNOTHX\" ]",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
                                         data_checkBoxDisable_enableGroup_param = "A1.SEXORNOTHX",
                                         data_checkBoxDisable_disableGroup_param = "A1.SEXORNDNK,A1.SEXORNNOAN",
-                                        data_checkboxDisable_toggleState_param = "true"
-
-                                    })
+                                        data_checkboxDisable_toggleState_param = "true",
+                                        data_checkboxDisable_disableOnLoad_param = "A1.SEXORNOTHX"
+                                        })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.SEXORNOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNOTH)</label>

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -795,7 +795,7 @@
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.SexualOrientstionIndicated"></span>
             </div>
             <div class="mt-4 sm:col-span-2 sm:mt-0">
-                <fieldset class="subsubcounterreset">
+                <fieldset class="subcounterreset">
                     <div class="space-y-1">
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -744,7 +744,7 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENOTHX",
+                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENNOANS",
                                         data_checkboxDisable_disable_param = "true"
                                     })
                             </div>
@@ -760,7 +760,7 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN,A1.GENOTHX",
+                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN,A1.GENOTH",
                                         data_checkboxDisable_disable_param = "true"
                                     })
                             </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -742,7 +742,7 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH",
+                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENOTHX",
                                         data_checkboxDisable_disable_param = "true"
                                     })
                             </div>
@@ -758,7 +758,7 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN",
+                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN,A1.GENOTHX",
                                         data_checkboxDisable_disable_param = "true"
                                     })
                             </div>
@@ -860,7 +860,7 @@
                                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH",
+                                        data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNOTHX",
                                         data_checkboxDisable_disable_param = "true"
                                     })
                             </div>
@@ -874,8 +874,9 @@
                                 @Html.CheckBox("A1.SEXORNNOAN", Model.A1.SEXORNNOAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
                                 data_checkBoxDisable_target = "checkboxTrigger",
                                 data_action = "input->checkboxDisable#ToggleGroup",
-                                data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNDNK",
-                                data_checkboxDisable_disable_param = "true"
+
+                                        data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNDNK,A1.SEXORNOTHX",
+                                        data_checkboxDisable_disable_param = "true"
                                 })
                             </div>
                             <div class="ml-3 text-sm leading-6">

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -723,15 +723,11 @@
                                 <div class="flex h-6 items-center">
                                     <!--// GENOTH is pretty complex because it needs to enable and also disable //-->
                                     @Html.CheckBox("A1.GENOTH", Model.A1.GENOTH, new
-                                    {
-                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
-                                        data_checkBoxDisable_target = "checkboxTrigger",
-                                        data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_enableGroup_param = "A1.GENOTHX",
-                                        data_checkBoxDisable_disableGroup_param = "A1.GENDKN,A1.GENNOANS",
-                                        data_checkboxDisable_toggleState_param = "true",
-                                        data_checkboxDisable_disableOnLoad_param = "A1.GENOTHX"
-                                        })
+                               {
+                                   @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
+                                   data_affects = "true",
+                                   data_affects_toggle_targets = "[ \"A1.GENOTHX\"]"
+                               })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.GENOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENOTH)</label>
@@ -852,16 +848,12 @@
                             <div class="relative flex items-start">
                                 <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                                 <div class="flex h-6 items-center">
-                                    @Html.CheckBox("A1.SEXORNOTH", Model.A1.SEXORNOTH, new 
-                                    { 
-                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
-                                        data_checkBoxDisable_target = "checkboxTrigger",
-                                        data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_enableGroup_param = "A1.SEXORNOTHX",
-                                        data_checkBoxDisable_disableGroup_param = "A1.SEXORNDNK,A1.SEXORNNOAN",
-                                        data_checkboxDisable_toggleState_param = "true",
-                                        data_checkboxDisable_disableOnLoad_param = "A1.SEXORNOTHX"
-                                        })
+                                    @Html.CheckBox("A1.SEXORNOTH", Model.A1.SEXORNOTH, new
+                               {
+                                   @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
+                                   data_affects = "true",
+                                   data_affects_toggle_targets = "[ \"A1.SEXORNOTHX\"]"
+                               })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.SEXORNOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNOTH)</label>

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -724,7 +724,8 @@
                                     <!--// GENOTH is pretty complex because it needs to enable and also disable //-->
                                     @Html.CheckBox("A1.GENOTH", Model.A1.GENOTH, new
                                     {
-                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
+                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
+                                        data_affects = "true", data_affects_toggle_targets = "[ \"A1.GENOTHX\"]",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
                                         data_checkBoxDisable_enableGroup_param = "A1.GENOTHX",
@@ -851,7 +852,17 @@
                             <div class="relative flex items-start">
                                 <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                                 <div class="flex h-6 items-center">
-                                    @Html.CheckBox("A1.SEXORNOTH", Model.A1.SEXORNOTH, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", data_affects = "true", data_affects_toggle_targets = "[ \"A1.SEXORNOTHX\" ]" })
+                                    @Html.CheckBox("A1.SEXORNOTH", Model.A1.SEXORNOTH, new 
+                                    { 
+                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
+                                        data_affects = "true", data_affects_toggle_targets = "[ \"A1.SEXORNOTHX\" ]",
+                                        data_checkBoxDisable_target = "checkboxTrigger",
+                                        data_action = "input->checkboxDisable#ToggleGroup",
+                                        data_checkBoxDisable_enableGroup_param = "A1.SEXORNOTHX",
+                                        data_checkBoxDisable_disableGroup_param = "A1.SEXORNDNK,A1.SEXORNNOAN",
+                                        data_checkboxDisable_toggleState_param = "true"
+
+                                    })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.SEXORNOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNOTH)</label>
@@ -875,7 +886,7 @@
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
                                         data_checkBoxDisable_enableGroup_param = "",
-                                        data_checkBoxDisable_disableGroup_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNOTHX",
+                                        data_checkBoxDisable_disableGroup_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNNOAN",
                                         data_checkboxDisable_toggleState_param = "true"
                                     })
                             </div>
@@ -892,7 +903,7 @@
                                     data_checkBoxDisable_target = "checkboxTrigger",
                                     data_action = "input->checkboxDisable#ToggleGroup",
                                     data_checkBoxDisable_enableGroup_param = "",
-                                    data_checkBoxDisable_disableGroup_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNDNK,A1.SEXORNOTHX",
+                                    data_checkBoxDisable_disableGroup_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNDNK",
                                     data_checkboxDisable_toggleState_param = "true"
                                 })
                             </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -1,7 +1,8 @@
-﻿@page  "{id:int?}"
+﻿@page "{id:int?}"
 @model UDS.Net.Forms.Pages.UDS4.A1Model
 @{
     Layout = "_LayoutForm";
+
     string rowCSS = "sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6";
 }
 
@@ -738,10 +739,10 @@
                             <div class="flex h-6 items-center">
                                 @Html.CheckBox("A1.GENDKN", Model.A1.GENDKN, new
                                     {
-                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" ,
+                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
                                         data_checkBoxDisable_target = "checkboxTrigger",
                                         data_action = "input->checkboxDisable#ToggleGroup",
-                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENTWOSPIR,A1.GENOTH",
+                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH",
                                         data_checkboxDisable_disable_param = "true"
                                     })
                             </div>
@@ -752,7 +753,14 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.GENNOANS", Model.A1.GENNOANS, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.GENNOANS", Model.A1.GENNOANS, new
+                                    {
+                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
+                                        data_checkBoxDisable_target = "checkboxTrigger",
+                                        data_action = "input->checkboxDisable#ToggleGroup",
+                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN",
+                                        data_checkboxDisable_disable_param = "true"
+                                    })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.GENNOANS" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENNOANS)</label>
@@ -781,7 +789,7 @@
             </div>
         </div>
 
-        <div class="ml-2 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
+        <div class="ml-2 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6" data-controller="checkboxDisable">
             <div>
                 <label class="text-base font-semibold text-gray-900"><span class="counter"></span>Which term(s) best describes your sexual orientation? (Check all that apply)</label><br />
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.SexualOrientstionIndicated"></span>
@@ -792,7 +800,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.SEXORNGAY", Model.A1.SEXORNGAY, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.SEXORNGAY", Model.A1.SEXORNGAY, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.SEXORNGAY" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNGAY)</label>
@@ -801,7 +809,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.SEXORNHET", Model.A1.SEXORNHET, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.SEXORNHET", Model.A1.SEXORNHET, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.SEXORNHET" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNHET)</label>
@@ -810,7 +818,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.SEXORNBI", Model.A1.SEXORNBI, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.SEXORNBI", Model.A1.SEXORNBI, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.SEXORNBI" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNBI)</label>
@@ -829,7 +837,7 @@
                             <div class="relative flex items-start">
                                 <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                                 <div class="flex h-6 items-center">
-                                    @Html.CheckBox("A1.SEXORNOTH", Model.A1.SEXORNOTH, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600", data_affects = "true", data_affects_toggle_targets = "[ \"A1.SEXORNOTHX\" ]" })
+                                    @Html.CheckBox("A1.SEXORNOTH", Model.A1.SEXORNOTH, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", data_affects = "true", data_affects_toggle_targets = "[ \"A1.SEXORNOTHX\" ]" })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.SEXORNOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNOTH)</label>
@@ -847,7 +855,14 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.SEXORNDNK", Model.A1.SEXORNDNK, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.SEXORNDNK", Model.A1.SEXORNDNK, new
+                                    {
+                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
+                                        data_checkBoxDisable_target = "checkboxTrigger",
+                                        data_action = "input->checkboxDisable#ToggleGroup",
+                                        data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH",
+                                        data_checkboxDisable_disable_param = "true"
+                                    })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.SEXORNDNK" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNDNK)</label>
@@ -856,7 +871,12 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.SEXORNNOAN", Model.A1.SEXORNNOAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.SEXORNNOAN", Model.A1.SEXORNNOAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", 
+                                data_checkBoxDisable_target = "checkboxTrigger",
+                                data_action = "input->checkboxDisable#ToggleGroup",
+                                data_checkBoxDisable_group_param = "A1.SEXORNGAY,A1.SEXORNHET,A1.SEXORNBI,A1.SEXORNOTH,A1.SEXORNDNK",
+                                data_checkboxDisable_disable_param = "true"
+                                })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.SEXORNNOAN" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.SEXORNNOAN)</label>

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -652,7 +652,7 @@
         </div>
 
 
-        <div class="ml-2 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
+        <div class="ml-2 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6" data-controller="checkboxDisable">
             <div>
                 <label class="text-base font-semibold text-gray-900"><span class="counter"></span>Which term(s) best describes your current gender identity? (Check all that apply)</label><br />
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A1.GenderIdentityIndicated"></span>
@@ -663,7 +663,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.GENMAN", Model.A1.GENMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.GENMAN", Model.A1.GENMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.GENMAN" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENMAN)</label>
@@ -672,7 +672,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.GENWOMAN", Model.A1.GENWOMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.GENWOMAN", Model.A1.GENWOMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.GENWOMAN" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENWOMAN)</label>
@@ -681,7 +681,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.GENTRMAN", Model.A1.GENTRMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.GENTRMAN", Model.A1.GENTRMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.GENTRMAN" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENTRMAN)</label>
@@ -690,7 +690,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.GENTRWOMAN", Model.A1.GENTRWOMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.GENTRWOMAN", Model.A1.GENTRWOMAN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.GENTRWOMAN" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENTRWOMAN)</label>
@@ -699,7 +699,7 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.GENNONBI", Model.A1.GENNONBI, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.GENNONBI", Model.A1.GENNONBI, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.GENNONBI" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENNONBI)</label>
@@ -718,7 +718,7 @@
                             <div class="relative flex items-start">
                                 <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                                 <div class="flex h-6 items-center">
-                                    @Html.CheckBox("A1.GENOTH", Model.A1.GENOTH, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600", data_affects = "true", data_affects_toggle_targets = "[ \"A1.GENOTHX\" ]" })
+                                    @Html.CheckBox("A1.GENOTH", Model.A1.GENOTH, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none", data_affects = "true", data_affects_toggle_targets = "[ \"A1.GENOTHX\" ]" })
                                 </div>
                                 <div class="ml-3 text-sm leading-6">
                                     <label asp-for="A1.GENOTH" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENOTH)</label>
@@ -736,7 +736,14 @@
                         <div class="relative flex items-start">
                             <span class="subcounter mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
                             <div class="flex h-6 items-center">
-                                @Html.CheckBox("A1.GENDKN", Model.A1.GENDKN, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" })
+                                @Html.CheckBox("A1.GENDKN", Model.A1.GENDKN, new
+                                    {
+                                        @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" ,
+                                        data_checkBoxDisable_target = "checkboxTrigger",
+                                        data_action = "input->checkboxDisable#ToggleGroup",
+                                        data_checkBoxDisable_group_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENTWOSPIR,A1.GENOTH",
+                                        data_checkboxDisable_disable_param = "true"
+                                    })
                             </div>
                             <div class="ml-3 text-sm leading-6">
                                 <label asp-for="A1.GENDKN" class="font-medium text-gray-900">@Html.DisplayNameFor(m => m.A1.GENDKN)</label>

--- a/src/UDS.Net.Forms/Pages/UDS4/A1a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1a.cshtml
@@ -712,11 +712,14 @@
                     <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">39a14.</span>
                 </div>
                 <div>
-                    @Html.CheckBox("A1a.EXPNOTAPP", Model.A1a.EXPNOTAPP, new { @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600",
-                    data_checkBoxDisable_target="checkboxTrigger",
-                    data_action="input->checkboxDisable#ToggleGroup",
-                    data_checkBoxDisable_group_param = "A1a.EXPSTRS",
-                    data_checkboxDisable_disable_param = "true" })
+                    @Html.CheckBox("A1a.EXPNOTAPP", Model.A1a.EXPNOTAPP, new 
+                    {   @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600",
+                        data_checkBoxDisable_target="checkboxTrigger",
+                        data_action="input->checkboxDisable#ToggleGroup",
+                        data_checkBoxDisable_disableGroup_param = "A1a.EXPSTRS",
+                        data_checkBoxDisable_enableGroup_param = "",
+                        data_checkboxDisable_toggleState_param = "true"
+                    })
                 </div>
                 <div>
                     <label asp-for="A1a.EXPNOTAPP"></label>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.6.6</Version>
+		<Version>4.6.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.6</ReleaseVersion>
+		<ReleaseVersion>4.6.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
+++ b/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
@@ -68,7 +68,9 @@
             </div>
 
             <div class="divide-y divide-gray-200">
-                <form method="post" id="UDSForm">
+                @if(Model.BaseForm.Kind != "C2" || Model.BaseForm.Kind != "C2T")
+                {
+                <form method="post" id="UDSForm" data-turbo="false">
                     <input name="Enum.FormMode.NotCompleted" value="@(((int)FormMode.NotCompleted).ToString())" type="hidden" />
                     <input name="Enum.FormStatus.Finalized" value="@(((int)FormStatus.Finalized).ToString())" type="hidden" />
                     <input asp-for="Visit.Id" type="hidden" />
@@ -88,7 +90,32 @@
 
                         @RenderBody()
                     </div>
-                </form>
+                    </form>
+                }
+                else
+                {
+                    <form method="post" id="UDSForm">
+                        <input name="Enum.FormMode.NotCompleted" value="@(((int)FormMode.NotCompleted).ToString())" type="hidden" />
+                        <input name="Enum.FormStatus.Finalized" value="@(((int)FormStatus.Finalized).ToString())" type="hidden" />
+                        <input asp-for="Visit.Id" type="hidden" />
+                        <input asp-for="Visit.ParticipationId" type="hidden" />
+                        <input asp-for="Visit.VISITNUM" type="hidden" />
+                        <input asp-for="Visit.PACKET" type="hidden" />
+                        <input asp-for="Visit.FORMVER" type="hidden" />
+                        <input asp-for="Visit.VISIT_DATE" type="hidden" />
+                        <input asp-for="Visit.INITIALS" type="hidden" />
+                        <input asp-for="Visit.CreatedAt" type="hidden" />
+                        <input asp-for="Visit.CreatedBy" type="hidden" />
+                        <input asp-for="Visit.ModifiedBy" type="hidden" />
+                        <input asp-for="Visit.DeletedBy" type="hidden" />
+                        <input asp-for="Visit.IsDeleted" type="hidden" />
+
+                        <div class="counterreset space-y-12 sm:space-y-16 mt-2">
+
+                            @RenderBody()
+                        </div>
+                    </form>
+                }
             </div>
         </main>
 

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -17,6 +17,11 @@ HTML USAGE:
 
 */
 
+/*
+ TODO This controller was initally created to support the A1a form. The complexity grew when the code was modified to support the A1 form as well.
+ We should be able to refactor this so that it uses the stimulus targets instead of the the group params that are currently used.
+*/
+
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
@@ -57,11 +62,6 @@ export default class extends Controller {
   ToggleGroup(event) {
     const { enablegroup, disablegroup, togglestate } = event.params;
     const checkbox = event.currentTarget;
-    /*    console.log(event.params);*/
-
-    //if (togglestate == undefined || enablegroup == undefined || disablegroup == undefined) {
-    //  return console.error($'Missing required parameters on a target element with id: this.event.checkbox')
-    //}
 
     var isChecked = checkbox.checked
 
@@ -74,9 +74,6 @@ export default class extends Controller {
       this.IterateAndSetDisable(disablegroup, false);
     }
 
-
-
-
   }
 
   OnLoad() {
@@ -84,10 +81,8 @@ export default class extends Controller {
       let toggleStateString = checkbox.dataset.checkboxdisableTogglestateParam
       let enablegroup = checkbox.dataset.checkboxdisableEnablegroupParam
       let disablegroup = checkbox.dataset.checkboxdisableDisablegroupParam
+      let disableElement = checkbox.dataset.checkboxdisableDisableonloadParam
 
-      console.log(toggleStateString);
-      console.log(enablegroup);
-      console.log(disablegroup);
       //due to javascript typing, a boolean needs to be set manually to the destructured parameter or it will read as a string
       //Stimulus only assumes type when using params with an action
       let togglestate = new Boolean()
@@ -98,10 +93,28 @@ export default class extends Controller {
       if (toggleStateString == "true")
         togglestate = true
 
-      if (checkbox.checked) {
-        this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox })
-        break;
+      if (checkbox.dataset.checkboxdisableDisableonloadParam == undefined) {
+        if (checkbox.checked) {
+          this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox })
+        }
+      }
+
+      if (checkbox.dataset.checkboxdisableDisableonloadParam) {
+        if (checkbox.checked) {
+          this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox });
+        } else {
+          this.DisableElement(disableElement);
+        }
       }
     }
+  }
+
+  DisableElement(element) {
+
+    var targetElements = document.getElementsByName(element.trim());
+    targetElements.forEach((element) => {
+      element.disabled = true;
+    })
+
   }
 }

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -97,9 +97,11 @@ export default class extends Controller {
         togglestate = true
 
       // Need to call toggle group on each checkboxDisable checkbox
-      console.log("Setting up state for " + checkbox.id);
-      // TODO if checkbox is disabled, don't run togglegroup
-      this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox });
+      // console.log("Setting up state for " + checkbox.id);
+      // if checkbox is disabled, don't run togglegroup
+      if (checkbox.disabled == false) {
+        this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox });
+      }
     }
   }
 }

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -98,6 +98,7 @@ export default class extends Controller {
 
       // Need to call toggle group on each checkboxDisable checkbox
       console.log("Setting up state for " + checkbox.id);
+      // TODO if checkbox is disabled, don't run togglegroup
       this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox });
     }
   }

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -59,6 +59,9 @@ export default class extends Controller {
     });
   }
 
+  /*
+    ToggleGroup is called when the checkbox is changed
+  */
   ToggleGroup(event) {
     const { enablegroup, disablegroup, togglestate } = event.params;
     const checkbox = event.currentTarget;
@@ -93,28 +96,9 @@ export default class extends Controller {
       if (toggleStateString == "true")
         togglestate = true
 
-      if (checkbox.dataset.checkboxdisableDisableonloadParam == undefined) {
-        if (checkbox.checked) {
-          this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox })
-        }
-      }
-
-      if (checkbox.dataset.checkboxdisableDisableonloadParam) {
-        if (checkbox.checked) {
-          this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox });
-        } else {
-          this.DisableElement(disableElement);
-        }
-      }
+      // Need to call toggle group on each checkboxDisable checkbox
+      console.log("Setting up state for " + checkbox.id);
+      this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox });
     }
-  }
-
-  DisableElement(element) {
-
-    var targetElements = document.getElementsByName(element.trim());
-    targetElements.forEach((element) => {
-      element.disabled = true;
-    })
-
   }
 }

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -3,13 +3,17 @@ DESCRIPTION:
 checkboxDisable_controller.js is for custom UI behavior for disabling and enabling inputs by their name attribute when a checkbox is checked, using stimulus.js
 
 HTML USAGE:
-<div>
-    @Html.CheckBox("A1a.EXPNOTAPP", Model.A1a.EXPNOTAPP, new {@class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600",
-        data_checkBoxDisable_target = "checkboxTrigger",
-        data_action = "input->checkboxDisable#ToggleGroup",
-        data_checkBoxDisable_group_param = "A1a.EXPSTRS",
-        data_checkboxDisable_disable_param = "true"})
-</div>
+     <div class="flex h-6 items-center">
+                 @Html.CheckBox("A1.GENNOANS", Model.A1.GENNOANS, new
+                     {
+                         @class = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
+                         data_checkBoxDisable_target = "checkboxTrigger",
+                         data_action = "input->checkboxDisable#ToggleGroup",
+                         data_checkBoxDisable_enableGroup_param = "",
+                         data_checkBoxDisable_disableGroup_param = "A1.GENMAN,A1.GENWOMAN,A1.GENTRMAN,A1.GENTRWOMAN,A1.GENNONBI,A1.GENOTH,A1.GENDKN,A1.GENOTH",
+                         data_checkboxDisable_toggleState_param = "true"
+                     })
+             </div>
 
 STIMULUS PARAMETERS:
 data_checkboxDisable_group_param = the name of the input(s) you are wanting to disable
@@ -43,7 +47,7 @@ export default class extends Controller {
       //get all elements that are to be affected by checkbox using javascript
       var targetElements = document.getElementsByName(propertyName.trim());
 
-      if (targetElements.length < 1) {
+      if (targetElements.length == undefined) {
         return console.warn('No targets found to be affected by checkbox of id: ${checkbox.id} for property: ${propertyName}')
       }
 
@@ -56,15 +60,13 @@ export default class extends Controller {
   ToggleGroup(event) {
     const { enablegroup, disablegroup, togglestate } = event.params;
     const checkbox = event.currentTarget;
-    console.log(event.params);
+    /*    console.log(event.params);*/
 
     if (togglestate == undefined || enablegroup == undefined || disablegroup == undefined) {
       return console.error('Missing required parameters on a target element with id: ${this.checkboxTriggerTarget.id}')
     }
 
     var isChecked = checkbox.checked
-    //apply disable value if the checkbox is checked and the opposite when unchecked
-    //var disableValue = isChecked ? disable : !disable
 
     if (isChecked == togglestate) {
       this.IterateAndSetDisable(enablegroup, false);
@@ -86,9 +88,9 @@ export default class extends Controller {
       let enableGroup = checkbox.dataset.checkboxdisableEnablegroupParam
       let disableGroup = checkbox.dataset.checkboxdisableDisablegroupParam
 
-      console.log(toggleStateString);
-      console.log(enableGroup);
-      console.log(disableGroup);
+      //console.log(toggleStateString);
+      //console.log(enableGroup);
+      //console.log(disableGroup);
       //due to javascript typing, a boolean needs to be set manually to the destructured parameter or it will read as a string
       //Stimulus only assumes type when using params with an action
       let toggleState = new Boolean()

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -25,18 +25,18 @@ export default class extends Controller {
     this.OnLoad()
   }
 
-  ToggleGroup(event) {
-    const { group, disable } = event.params;
-    const checkbox = event.currentTarget;
+  /*
+    There are only two states to a checkbox. We need:
+    1. Which state will control the toggle (currently named disable)
+    2. When the toggle is activated then EnableGroup inputs will be enabled
+    3. When the toggle is activated then DisableGroup inputs will be disabled
+  */
 
-    if (group == undefined || disable == undefined) {
-      return console.error(`Missing required parameter of group or disable on a target element with id: ${this.checkboxTriggerTarget.id}`)
-    }
-
-    var isChecked = checkbox.checked
-    //apply disable value if the checkbox is checked and the opposite when unchecked
-    var disableValue = isChecked ? disable : !disable
+  IterateAndSetDisable(group, disableValue) {
     //split the group parameter into an array of property names
+    if (group == undefined) {
+      return console.log('Nothing here to change the state to');
+    }
     var propertyNames = group.split(',')
 
     propertyNames.forEach(propertyName => {
@@ -44,32 +44,63 @@ export default class extends Controller {
       var targetElements = document.getElementsByName(propertyName.trim());
 
       if (targetElements.length < 1) {
-        return console.warn(`No targets found to be affected by checkbox of id: ${checkbox.id} for property: ${propertyName}`)
+        return console.warn('No targets found to be affected by checkbox of id: ${checkbox.id} for property: ${propertyName}')
       }
 
       targetElements.forEach((element) => {
-        element.disabled = disableValue
+        element.disabled = disableValue;
       })
-    })
+    });
+  }
+
+  ToggleGroup(event) {
+    const { enablegroup, disablegroup, togglestate } = event.params;
+    const checkbox = event.currentTarget;
+    console.log(event.params);
+
+    if (togglestate == undefined || enablegroup == undefined || disablegroup == undefined) {
+      return console.error('Missing required parameters on a target element with id: ${this.checkboxTriggerTarget.id}')
+    }
+
+    var isChecked = checkbox.checked
+    //apply disable value if the checkbox is checked and the opposite when unchecked
+    //var disableValue = isChecked ? disable : !disable
+
+    if (isChecked == togglestate) {
+      this.IterateAndSetDisable(enablegroup, false);
+      this.IterateAndSetDisable(disablegroup, true);
+    }
+    else {
+      this.IterateAndSetDisable(enablegroup, true);
+      this.IterateAndSetDisable(disablegroup, false);
+    }
+
+
+
+
   }
 
   OnLoad() {
     for (let checkbox of this.checkboxTriggerTargets) {
-      let disableString = checkbox.dataset.checkboxdisableDisableParam
-      let group = checkbox.dataset.checkboxdisableGroupParam
+      let toggleStateString = checkbox.dataset.checkboxdisableTogglestateParam
+      let enableGroup = checkbox.dataset.checkboxdisableEnablegroupParam
+      let disableGroup = checkbox.dataset.checkboxdisableDisablegroupParam
 
+      console.log(toggleStateString);
+      console.log(enableGroup);
+      console.log(disableGroup);
       //due to javascript typing, a boolean needs to be set manually to the destructured parameter or it will read as a string
       //Stimulus only assumes type when using params with an action
-      let disable = new Boolean()
+      let toggleState = new Boolean()
 
-      if (disableString == "false")
-        disable = false
+      if (toggleStateString == "false")
+        toggleState = false
 
-      if (disableString == "true")
-        disable = true
+      if (toggleStateString == "true")
+        toggleState = true
 
       if (checkbox.checked) {
-        this.ToggleGroup({ params: { group, disable }, currentTarget: checkbox })
+        this.ToggleGroup({ params: { enableGroup, disableGroup, toggleState }, currentTarget: checkbox })
         break;
       }
     }

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -34,15 +34,20 @@ export default class extends Controller {
     var isChecked = this.checkboxTriggerTarget.checked
     //apply disable value if the checkbox is checked and the opposite when unchecked
     var disableValue = isChecked ? disable : !disable
-    //get all elements that are to be affected by checkbox using javascript
-    var targetElements = document.getElementsByName(group)
+    //split the group parameter into an array of property names
+    var propertyNames = group.split(',')
 
-    if (targetElements.length < 1) {
-      return console.warn(`No targets found to be affected by checkbox of id: ${this.checkboxTriggerTarget.id}`)
-    }
+    propertyNames.forEach(groupName => {
+      //get all elements that are to be affected by checkbox using javascript
+      var targetElements = document.getElementsByName(groupName.trim())
 
-    targetElements.forEach((element) => {
-      element.disabled = disableValue
+      if (targetElements.length < 1) {
+        return console.warn(`No targets found to be affected by checkbox of id: ${this.checkboxTriggerTarget.id} for group: ${groupName}`)
+      }
+
+      targetElements.forEach((element) => {
+        element.disabled = disableValue
+      })
     })
   }
 

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -54,7 +54,7 @@ export default class extends Controller {
   }
 
   OnLoad() {
-    this.checkboxTriggerTargets.forEach((checkbox) => {
+    for (let checkbox of this.checkboxTriggerTargets) {
       let disableString = checkbox.dataset.checkboxdisableDisableParam
       let group = checkbox.dataset.checkboxdisableGroupParam
 
@@ -68,7 +68,10 @@ export default class extends Controller {
       if (disableString == "true")
         disable = true
 
-      this.ToggleGroup({ params: { group, disable }, currentTarget: checkbox })
-    })
+      if (checkbox.checked) {
+        this.ToggleGroup({ params: { group, disable }, currentTarget: checkbox })
+        break;
+      }
+    }
   }
 }

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -25,24 +25,26 @@ export default class extends Controller {
     this.OnLoad()
   }
 
-  ToggleGroup({ params: { group, disable } }) {
+  ToggleGroup(event) {
+    const { group, disable } = event.params;
+    const checkbox = event.currentTarget;
 
     if (group == undefined || disable == undefined) {
       return console.error(`Missing required parameter of group or disable on a target element with id: ${this.checkboxTriggerTarget.id}`)
     }
 
-    var isChecked = this.checkboxTriggerTarget.checked
+    var isChecked = checkbox.checked
     //apply disable value if the checkbox is checked and the opposite when unchecked
     var disableValue = isChecked ? disable : !disable
     //split the group parameter into an array of property names
     var propertyNames = group.split(',')
 
-    propertyNames.forEach(groupName => {
+    propertyNames.forEach(propertyName => {
       //get all elements that are to be affected by checkbox using javascript
-      var targetElements = document.getElementsByName(groupName.trim())
+      var targetElements = document.getElementsByName(propertyName.trim());
 
       if (targetElements.length < 1) {
-        return console.warn(`No targets found to be affected by checkbox of id: ${this.checkboxTriggerTarget.id} for group: ${groupName}`)
+        return console.warn(`No targets found to be affected by checkbox of id: ${checkbox.id} for property: ${propertyName}`)
       }
 
       targetElements.forEach((element) => {
@@ -52,10 +54,9 @@ export default class extends Controller {
   }
 
   OnLoad() {
-    this.checkboxTriggerTargets.forEach(() => {
-
-      let disableString = this.checkboxTriggerTarget.dataset.checkboxdisableDisableParam
-      let group = this.checkboxTriggerTarget.dataset.checkboxdisableGroupParam
+    this.checkboxTriggerTargets.forEach((checkbox) => {
+      let disableString = checkbox.dataset.checkboxdisableDisableParam
+      let group = checkbox.dataset.checkboxdisableGroupParam
 
       //due to javascript typing, a boolean needs to be set manually to the destructured parameter or it will read as a string
       //Stimulus only assumes type when using params with an action
@@ -67,7 +68,7 @@ export default class extends Controller {
       if (disableString == "true")
         disable = true
 
-      this.ToggleGroup({ params: { group, disable } })
+      this.ToggleGroup({ params: { group, disable }, currentTarget: checkbox })
     })
   }
 }

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -15,9 +15,6 @@ HTML USAGE:
                      })
              </div>
 
-STIMULUS PARAMETERS:
-data_checkboxDisable_group_param = the name of the input(s) you are wanting to disable
-data_checkboxDisable_disable_param = a flag for if clicking the checkbox disables or enables the group. true = disable on check and false = enable on check
 */
 
 import { Controller } from '@hotwired/stimulus';

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js
@@ -59,9 +59,9 @@ export default class extends Controller {
     const checkbox = event.currentTarget;
     /*    console.log(event.params);*/
 
-    if (togglestate == undefined || enablegroup == undefined || disablegroup == undefined) {
-      return console.error('Missing required parameters on a target element with id: ${this.checkboxTriggerTarget.id}')
-    }
+    //if (togglestate == undefined || enablegroup == undefined || disablegroup == undefined) {
+    //  return console.error($'Missing required parameters on a target element with id: this.event.checkbox')
+    //}
 
     var isChecked = checkbox.checked
 
@@ -82,24 +82,24 @@ export default class extends Controller {
   OnLoad() {
     for (let checkbox of this.checkboxTriggerTargets) {
       let toggleStateString = checkbox.dataset.checkboxdisableTogglestateParam
-      let enableGroup = checkbox.dataset.checkboxdisableEnablegroupParam
-      let disableGroup = checkbox.dataset.checkboxdisableDisablegroupParam
+      let enablegroup = checkbox.dataset.checkboxdisableEnablegroupParam
+      let disablegroup = checkbox.dataset.checkboxdisableDisablegroupParam
 
-      //console.log(toggleStateString);
-      //console.log(enableGroup);
-      //console.log(disableGroup);
+      console.log(toggleStateString);
+      console.log(enablegroup);
+      console.log(disablegroup);
       //due to javascript typing, a boolean needs to be set manually to the destructured parameter or it will read as a string
       //Stimulus only assumes type when using params with an action
-      let toggleState = new Boolean()
+      let togglestate = new Boolean()
 
       if (toggleStateString == "false")
-        toggleState = false
+        togglestate = false
 
       if (toggleStateString == "true")
-        toggleState = true
+        togglestate = true
 
       if (checkbox.checked) {
-        this.ToggleGroup({ params: { enableGroup, disableGroup, toggleState }, currentTarget: checkbox })
+        this.ToggleGroup({ params: { enablegroup, disablegroup, togglestate }, currentTarget: checkbox })
         break;
       }
     }

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>4.6.6</ReleaseVersion>
+    <ReleaseVersion>4.6.7</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.6.6</Version>
+		<Version>4.6.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.6</ReleaseVersion>
+		<ReleaseVersion>4.6.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.6.6</Version>
+		<Version>4.6.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.6</ReleaseVersion>
+		<ReleaseVersion>4.6.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.6.6</ReleaseVersion>
+		<ReleaseVersion>4.6.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Fixes #206 

This PR adds validation to the following properties:

- GENDKN
- GENNOANS
- SEXORNDNK
- SEXORNNOAN
- SERVED

You can find the relevant NACC documentation [here](https://github.com/naccdata/uniform-data-set/blob/main/forms/uds/a1/form_a1_ivp_error_checks_p.csv)

During testing, I identified a bug that prevented the form from being submitted. The issue arose because Turbo expected a page redirect upon form submission. Although this form does not utilize Turbo Frames, the _LayoutForm partial, shared across all forms, includes the Turbo CDN.

To resolve this, I wrapped the form in an if statement and added the data-turbo="false" attribute to disable Turbo for forms other than C2 and C2T. You can review the commit addressing this fix [here](https://github.com/UK-SBCoA/uniform-data-set-dotnet-web/pull/218/commits/5916d09dbbe05ac0403a4c0f7d6393073a82d1bd)

To enable or disable properties dynamically, I used the [checkboxDisable_controller](https://github.com/UK-SBCoA/uniform-data-set-dotnet-web/blob/main/src/UDS.Net.Forms/wwwroot/js/js_controllers/checkboxDisable_controller.js). However, I had to modify its functionality.

When testing, it would be best to verify that the controller's functionality remains intact across other forms where it is implemented. It appears the A1a form is the only other form utilizing this controller.