### PR TITLE
A1 lookup

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>4.5.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.4.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
@@ -443,7 +443,7 @@ namespace UDS.Net.Forms.Pages.UDS4
 
                     if (countryCode.Code == null)
                     {
-                        ModelState.AddModelError(A1.CHLDHDCTRY, $"The country code \"{A1.CHLDHDCTRY}\" entered for question 2 ('CHLDHDCTRY') is invalid.");
+                        ModelState.AddModelError("A1.CHLDHDCTRY", $"The country code \"{A1.CHLDHDCTRY}\" entered for question 2 ('CHLDHDCTRY') is invalid.");
                     }
                 }
             }

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using UDS.Net.Forms.Extensions;
-using UDS.Net.Forms.Models;
+﻿using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel;
 using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Forms.Models.UDS4;
 using UDS.Net.Forms.TagHelpers;
@@ -17,6 +9,8 @@ namespace UDS.Net.Forms.Pages.UDS4
 {
     public class A1Model : FormPageModel
     {
+        protected readonly ILookupService _lookupService;
+
         [BindProperty]
         public A1 A1 { get; set; } = default!;
 
@@ -416,9 +410,12 @@ namespace UDS.Net.Forms.Pages.UDS4
             } }
         };
 
-        public A1Model(IVisitService visitService) : base(visitService, "A1")
+        public A1Model(IVisitService visitService, ILookupService lookupService) : base(visitService, "A1")
         {
+            _lookupService = lookupService;
         }
+
+
 
         public async Task<IActionResult> OnGetAsync(int? id)
         {
@@ -437,6 +434,12 @@ namespace UDS.Net.Forms.Pages.UDS4
         {
             BaseForm = A1; // reassign bounded and derived form to base form for base method
 
+            var countryCode = await _lookupService.LookupCountryCode(A1.CHLDHDCTRY);
+
+            if(countryCode.Error != null)
+            {
+                ModelState.AddModelError(A1.CHLDHDCTRY,$"The country code {A1.CHLDHDCTRY} entered for question 2 is invalid.");
+            }
             Visit.Forms.Add(A1); // visit needs updated form as well
 
             return await base.OnPostAsync(id); // checks for validation, etc.

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
@@ -4,6 +4,7 @@ using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Forms.Models.UDS4;
 using UDS.Net.Forms.TagHelpers;
 using UDS.Net.Services;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.Pages.UDS4
 {
@@ -434,12 +435,19 @@ namespace UDS.Net.Forms.Pages.UDS4
         {
             BaseForm = A1; // reassign bounded and derived form to base form for base method
 
-            var countryCode = await _lookupService.LookupCountryCode(A1.CHLDHDCTRY);
-
-            if(countryCode.Error != null)
+            if (BaseForm.Status == FormStatus.Finalized)
             {
-                ModelState.AddModelError(A1.CHLDHDCTRY,$"The country code {A1.CHLDHDCTRY} entered for question 2 is invalid.");
+                if (A1.CHLDHDCTRY != null)
+                {
+                    var countryCode = await _lookupService.LookupCountryCode(A1.CHLDHDCTRY);
+
+                    if (countryCode.Code == null)
+                    {
+                        ModelState.AddModelError(A1.CHLDHDCTRY, $"The country code \"{A1.CHLDHDCTRY}\" entered for question 2 ('CHLDHDCTRY') is invalid.");
+                    }
+                }
             }
+
             Visit.Forms.Add(A1); // visit needs updated form as well
 
             return await base.OnPostAsync(id); // checks for validation, etc.

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -25,8 +25,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.3.0" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.3.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0-preview.2" />
 		<PackageReference Include="CsvHelper" Version="33.0.1" />
 		<PackageReference Include="NSwag.ApiDescription.Client" Version="14.1.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.4.1</Version>
+		<Version>4.5.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.4.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.5.0-preview.1</Version>
+		<Version>4.5.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
+    <ReleaseVersion>4.5.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
+    <ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>4.4.1</ReleaseVersion>
+    <ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services/ILookupService.cs
+++ b/src/UDS.Net.Services/ILookupService.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using UDS.Net.Dto;
 using UDS.Net.Services.LookupModels;
 

--- a/src/UDS.Net.Services/ILookupService.cs
+++ b/src/UDS.Net.Services/ILookupService.cs
@@ -1,5 +1,6 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using UDS.Net.Dto;
 using UDS.Net.Services.LookupModels;
 
 namespace UDS.Net.Services
@@ -9,6 +10,8 @@ namespace UDS.Net.Services
         Task<DrugCodeLookup> LookupDrugCodes(int pageSize = 10, int pageIndex = 1);
 
         Task<DrugCodeLookup> SearchDrugCodes(int pageSize = 10, int pageIndex = 1, bool onlyPopular = true, string? searchTerm = "");
+
+        Task<LookupCountryCodeDto> LookupCountryCode(string countryCode);
 
     }
 }

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.4.1</Version>
+		<Version>4.5.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.4.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -13,7 +13,6 @@
 		<ReleaseVersion>4.4.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,15 +4,15 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.5.0-preview.2</Version>
+		<Version>4.5.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>4.5.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.5.0-preview.1</Version>
+		<Version>4.5.0-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -13,6 +13,7 @@
 		<ReleaseVersion>4.4.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="UDS.Net.Dto" Version="4.3.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Web.MVC.Services/LookupService.cs
+++ b/src/UDS.Net.Web.MVC.Services/LookupService.cs
@@ -63,7 +63,7 @@ namespace UDS.Net.Web.MVC.Services
         public async Task<LookupCountryCodeDto> LookupCountryCode(string countryCode)
         {
             var dto = await _apiClient.LookupClient.LookupCountryCode(countryCode);
-         
+
             return new LookupCountryCodeDto
             {
                 Id = dto.Id,

--- a/src/UDS.Net.Web.MVC.Services/LookupService.cs
+++ b/src/UDS.Net.Web.MVC.Services/LookupService.cs
@@ -3,12 +3,11 @@ using System;
 using UDS.Net.API.Client;
 using UDS.Net.Dto;
 using UDS.Net.Services;
-using UDS.Net.Services.Extensions;
-using UDS.Net.Services.DomainModels;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using UDS.Net.Services.LookupModels;
+using Microsoft.AspNetCore.Mvc;
 
 namespace UDS.Net.Web.MVC.Services
 {
@@ -58,6 +57,21 @@ namespace UDS.Net.Web.MVC.Services
                     IsPopular = r.IsPopular,
                     IsOverTheCounter = r.IsOverTheCounter
                 }).ToList()
+            };
+        }
+
+        public async Task<LookupCountryCodeDto> LookupCountryCode(string countryCode)
+        {
+            var dto = await _apiClient.LookupClient.LookupCountryCode(countryCode);
+         
+            return new LookupCountryCodeDto
+            {
+                Id = dto.Id,
+                Code = dto.Code,
+                Country = dto.Country,
+                IsActive = dto.IsActive,
+                ReasonChangedCode = dto.ReasonChangedCode,
+                Error = dto.Error
             };
         }
 

--- a/src/UDS.Net.Web.MVC.Services/LookupService.cs
+++ b/src/UDS.Net.Web.MVC.Services/LookupService.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using UDS.Net.Services.LookupModels;
-using Microsoft.AspNetCore.Mvc;
 
 namespace UDS.Net.Web.MVC.Services
 {

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -15,8 +15,8 @@
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.3.0" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.3.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0-preview.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Services\UDS.Net.Services.csproj" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.4.1</Version>
+		<Version>4.5.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.4.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.5.0-preview.1</Version>
+		<Version>4.5.0-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,19 +4,19 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.5.0-preview.2</Version>
+		<Version>4.5.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>4.5.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0-preview.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Services\UDS.Net.Services.csproj" />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.5.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>4.5.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -20,8 +20,8 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0-preview.2" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Forms\UDS.Net.Forms.csproj">

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.4.1</ReleaseVersion>
+		<ReleaseVersion>4.5.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -20,8 +20,8 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.3.0" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.3.0" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0-preview.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.4.0-preview.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Forms\UDS.Net.Forms.csproj">


### PR DESCRIPTION
Fixes #217 

This PR integrates the CountryCodesLookup table (introduced in [PR #80](https://github.com/UK-SBCoA/uniform-data-set-dotnet-api/pull/80)) to validate question 2 (CHLDHDCTRY) in the A1 form. Upon form submission, the value of CHLDHDCTRY is checked against the existing country codes in the database. If a match is found, the input is considered valid. Otherwise, a model error is raised, preventing form finalization.

When testing this PR, ensure the API references the v4.4.0-preview.2 NuGet package.