### PR TITLE
add rules and adjust existing rule

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.6.4</ReleaseVersion>
+		<ReleaseVersion>4.6.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -671,22 +671,24 @@ namespace UDS.Net.Forms.Models.UDS4
         }
 
         //non mapped property MOCARECN =! 88 && MOCARECC =! 88 && MOCARECR != 88 then all 3 properties should be <= 5
-        [RequiredOnFinalized(ErrorMessage = "If questions 1t, 1u, and 1v are NOT 88, then the sum of these 3 should be less than or equal to 5")]
+        [RequiredOnFinalized(ErrorMessage = "For Delayed recall questions: 'No cue', 'Category cue', and 'Recognition' the sum of questions with a value of 0 - 5 should be less than or equal to 5")]
         [NotMapped]
         public bool? DelayedRecallValidSum
         {
             get
             {
-                if (MOCARECN != 88 && MOCARECC != 88 && MOCARECR != 88)
-                {
-                    if (MOCARECN + MOCARECC + MOCARECR > 5) return null;
-                }
+                //if input is an exception value (93 - 95 or 88) then calculate as 0 in total
+                int? mocarecnValue = MOCARECN >= 95 || MOCARECN == null ? 0 : MOCARECN;
+                int? mocareccValue = MOCARECC == 88 || MOCARECC == null ? 0 : MOCARECC;
+                int? mocarecrValue = MOCARECR == 88 || MOCARECR == null ? 0 : MOCARECR;
+
+                if (mocarecnValue + mocareccValue + mocarecrValue > 5) return null;
 
                 return true;
             }
         }
 
-        [RequiredOnFinalized(ErrorMessage = "If question 1t is equal to 5, then 1u should equal 88 and 1v should equal 88")]
+        [RequiredOnFinalized(ErrorMessage = "If Delayed recall - No cue is equal to 5, then Delayed recall - Category cue and Delayed recall - Recognition should both be 88")]
         [NotMapped]
         public bool? MOCARECRAndMOCARECCValidValues
         {
@@ -694,14 +696,14 @@ namespace UDS.Net.Forms.Models.UDS4
             {
                 if (MOCARECN == 5)
                 {
-                    if (MOCARECC != 88 && MOCARECR != 88) return null;
+                    if (MOCARECC != 88 || MOCARECR != 88) return null;
                 }
 
                 return true;
             }
         }
 
-        [RequiredOnFinalized(ErrorMessage = "If the sum of questions 1t and 1u are equal to 5, then 1v should equal 88")]
+        [RequiredOnFinalized(ErrorMessage = "If the sum of Delayed recall - No cue and Delayed recall - Category are equal to 5, then Delayed recall - Recognition should be 88")]
         [NotMapped]
         public bool? MOCARECRValidValue
         {

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Diagnostics;
-using System.Reflection.Metadata;
-using System.Xml.Linq;
 using UDS.Net.Forms.DataAnnotations;
 using UDS.Net.Services.Enums;
 
@@ -674,6 +670,52 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
+        //non mapped property MOCARECN =! 88 && MOCARECC =! 88 && MOCARECR != 88 then all 3 properties should be <= 5
+        [RequiredOnFinalized(ErrorMessage = "If questions 1t, 1u, and 1v are NOT 88, then the sum of these 3 should be less than or equal to 5")]
+        [NotMapped]
+        public bool? DelayedRecallValidSum
+        {
+            get
+            {
+                if (MOCARECN != 88 && MOCARECC != 88 && MOCARECR != 88)
+                {
+                    if (MOCARECN + MOCARECC + MOCARECR > 5) return null;
+                }
+
+                return true;
+            }
+        }
+
+        [RequiredOnFinalized(ErrorMessage = "If question 1t is equal to 5, then 1u should equal 88 and 1v should equal 88")]
+        [NotMapped]
+        public bool? MOCARECRAndMOCARECCValidValues
+        {
+            get
+            {
+                if (MOCARECN == 5)
+                {
+                    if (MOCARECC != 88 && MOCARECR != 88) return null;
+                }
+
+                return true;
+            }
+        }
+
+        [RequiredOnFinalized(ErrorMessage = "If the sum of questions 1t and 1u are equal to 5, then 1v should equal 88")]
+        [NotMapped]
+        public bool? MOCARECRValidValue
+        {
+            get
+            {
+                if (MOCARECN + MOCARECC == 5)
+                {
+                    if (MOCARECR != 88) return null;
+                }
+
+                return true;
+            }
+        }
+
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             if (Status == Services.Enums.FormStatus.Finalized)
@@ -708,23 +750,6 @@ namespace UDS.Net.Forms.Models.UDS4
                     if (MOCATOTS.Value != 88)
                     {
                         yield return new ValidationResult("If 1g-1l, 1n-1t, or 1w-1bb were not administered then MOCATOTS must be 88.", new[] { nameof(MOCATOTS) });
-                    }
-                }
-
-                // 1t, 1u, 1v
-                // Page 8: https://files.alz.washington.edu/documentation/uds3-np-c2-instructions.pdf
-                if (MOCARECN.HasValue && MOCARECC.HasValue && MOCARECR.HasValue &&
-                    MOCARECN.Value < 95)
-                {
-                    int count = MOCARECN.Value;
-                    if (MOCARECC.Value != 88)
-                        count += MOCARECC.Value;
-                    if (MOCARECR.Value != 88)
-                        count += MOCARECR.Value;
-
-                    if (count > 5)
-                    {
-                        yield return new ValidationResult("The total possible words recalled and entered in Questions 1t, 1u, and 1v should be 5 or less.", new[] { nameof(MOCARECN) });
                     }
                 }
 

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -670,7 +670,6 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
-        //non mapped property MOCARECN =! 88 && MOCARECC =! 88 && MOCARECR != 88 then all 3 properties should be <= 5
         [RequiredOnFinalized(ErrorMessage = "For Delayed recall questions: 'No cue', 'Category cue', and 'Recognition' the sum of questions with a value of 0 - 5 should be less than or equal to 5")]
         [NotMapped]
         public bool? DelayedRecallValidSum

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -677,10 +677,25 @@ namespace UDS.Net.Forms.Models.UDS4
         {
             get
             {
+                int? mocarecnValue = 0;
+                int? mocareccValue = 0;
+                int? mocarecrValue = 0;
+
                 //if input is an exception value (93 - 95 or 88) then calculate as 0 in total
-                int? mocarecnValue = MOCARECN >= 95 || MOCARECN == null ? 0 : MOCARECN;
-                int? mocareccValue = MOCARECC == 88 || MOCARECC == null ? 0 : MOCARECC;
-                int? mocarecrValue = MOCARECR == 88 || MOCARECR == null ? 0 : MOCARECR;
+                if (MOCARECN != null)
+                {
+                    mocarecnValue = MOCARECN >= 95 ? 0 : MOCARECN;
+                }
+
+                if (MOCARECC != null)
+                {
+                    mocareccValue = MOCARECC == 88 ? 0 : MOCARECC;
+                }
+
+                if (MOCARECR != null)
+                {
+                    mocarecrValue = MOCARECR == 88 ? 0 : MOCARECR;
+                }
 
                 if (mocarecnValue + mocareccValue + mocarecrValue > 5) return null;
 

--- a/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using UDS.Net.Forms.Extensions;
+﻿using Microsoft.AspNetCore.Mvc;
 using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Forms.Models.UDS4;
 using UDS.Net.Forms.TagHelpers;

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -247,7 +247,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECN"></p>
                 </div>
+            </div>
+            <div>    
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECN"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.DelayedRecallValidSum"></span>
             </div>
 
             <div class="@rowCSS">
@@ -259,7 +262,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECC"></p>
                 </div>
+            </div>
+            <div>    
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECC"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRAndMOCARECCValidValues"></span>
             </div>
 
             <div class="@rowCSS">
@@ -271,7 +277,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECR"></p>
                 </div>
+            </div>
+            <div>    
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRValidValue"></span>
             </div>
 
             <div class="@rowCSS">

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -248,7 +248,7 @@
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECN"></p>
                 </div>
             </div>
-            <div>    
+            <div class="flex flex-col">
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECN"></span>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.DelayedRecallValidSum"></span>
             </div>
@@ -263,7 +263,7 @@
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECC"></p>
                 </div>
             </div>
-            <div>    
+            <div class="flex flex-col">
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECC"></span>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRAndMOCARECCValidValues"></span>
             </div>
@@ -278,7 +278,7 @@
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECR"></p>
                 </div>
             </div>
-            <div>    
+            <div class="flex flex-col">
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRValidValue"></span>
             </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -247,10 +247,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECN"></p>
                 </div>
-            </div>
-            <div class="flex flex-col">
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECN"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.DelayedRecallValidSum"></span>
+                <div>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECN"></span>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.DelayedRecallValidSum"></span>
+                </div>
             </div>
 
             <div class="@rowCSS">
@@ -262,10 +262,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECC"></p>
                 </div>
-            </div>
-            <div class="flex flex-col">
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECC"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRAndMOCARECCValidValues"></span>
+                <div>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECC"></span>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRAndMOCARECCValidValues"></span>
+                </div>
             </div>
 
             <div class="@rowCSS">
@@ -277,10 +277,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECR"></p>
                 </div>
-            </div>
-            <div class="flex flex-col">
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRValidValue"></span>
+                <div>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRValidValue"></span>
+                </div>
             </div>
 
             <div class="@rowCSS">

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
@@ -152,11 +152,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECN"></p>
                 </div>
-            </div>
-
-            <div class="flex flex-col">
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECN"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.DelayedRecallValidSum"></span>
+                <div>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECN"></span>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.DelayedRecallValidSum"></span>
+                </div>
             </div>
 
             <div class="@rowCSS">
@@ -168,11 +167,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECC"></p>
                 </div>
-            </div>
-
-            <div class="flex flex-col">
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECC"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRAndMOCARECCValidValues"></span>
+                <div>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECC"></span>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRAndMOCARECCValidValues"></span>
+                </div>
             </div>
 
             <div class="@rowCSS">
@@ -184,11 +182,10 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECR"></p>
                 </div>
-            </div>
-
-            <div class="flex flex-col">
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRValidValue"></span>
+                <div>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRValidValue"></span>
+                </div>
             </div>
 
             <div class="@rowCSS">

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
@@ -152,7 +152,11 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECN"></p>
                 </div>
+            </div>
+
+            <div class="flex flex-col">
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECN"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.DelayedRecallValidSum"></span>
             </div>
 
             <div class="@rowCSS">
@@ -164,7 +168,11 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECC"></p>
                 </div>
+            </div>
+
+            <div class="flex flex-col">
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECC"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRAndMOCARECCValidValues"></span>
             </div>
 
             <div class="@rowCSS">
@@ -176,8 +184,13 @@
                     </div>
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCARECR"></p>
                 </div>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
             </div>
+
+            <div class="flex flex-col">
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECR"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCARECRValidValue"></span>
+            </div>
+
             <div class="@rowCSS">
                 <label asp-for="C2.MOCAORDT"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.MOCAORDT)</label>
 

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.6.4</Version>
+		<Version>4.6.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.4</ReleaseVersion>
+		<ReleaseVersion>4.6.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>4.6.4</ReleaseVersion>
+    <ReleaseVersion>4.6.5</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.6.4</Version>
+		<Version>4.6.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.4</ReleaseVersion>
+		<ReleaseVersion>4.6.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.6.4</Version>
+		<Version>4.6.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.4</ReleaseVersion>
+		<ReleaseVersion>4.6.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.6.4</ReleaseVersion>
+		<ReleaseVersion>4.6.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
FIxes: #221 

These questions are the focus of the PR. The numbering can change depending on the form types, but the labels and validation will remain the same.

![image](https://github.com/user-attachments/assets/eb632d92-3b0f-434f-8cc6-a093b5eb402d)

example of error text display

![image](https://github.com/user-attachments/assets/9ae56737-33b5-4b21-8fba-37c24678f965)



## Adjust the validation for the C2 in all versions of the form (InPerson and remote): 
- [ ] For Delayed recall questions: 'No cue', 'Category cue', and 'Recognition' the sum of questions with a value of 0 - 5 should be less than or equal to 5
- [ ] If Delayed recall - No cue is equal to 5, then Delayed recall - Category cue and Delayed recall - Recognition should both be 88
- [ ] If the sum of Delayed recall - No cue and Delayed recall - Category are equal to 5, then Delayed recall - Recognition should be 88