### PR TITLE
Added loading spinner

### DIFF
--- a/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml
@@ -71,13 +71,13 @@
 </div>
 <turbo-frame id="C2">
     <div role="status" id="loadingSpinner" style="display: none;">
-        <button type="button" class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-white bg-indigo-500 hover:bg-indigo-400 transition ease-in-out duration-150 cursor-not-allowed" disabled>
+        <div class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-white bg-indigo-500">
             <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-white" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
             </svg>
             Loading...
-        </button>
+        </div>
     </div>
 
     @if (Model.Visit != null && (Model.C2.RMMODE == RemoteModality.Telephone))

--- a/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml
@@ -70,7 +70,7 @@
     <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.C2.RMMODE"></span>
 </div>
 <turbo-frame id="C2">
-    <div role="status" id="loadingSpinner" class="loading-spinner">
+    <div role="status" id="loadingSpinner" style="display: none;">
         <button type="button" class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-white bg-indigo-500 hover:bg-indigo-400 transition ease-in-out duration-150 cursor-not-allowed" disabled>
             <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-white" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml
@@ -70,14 +70,21 @@
     <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.C2.RMMODE"></span>
 </div>
 <turbo-frame id="C2">
-    @if (Model.Visit != null && (Model.C2.RMMODE == RemoteModality.Telephone))
+    <div role="status" id="loadingSpinner" class="loading-spinner">
+        <button type="button" class="inline-flex items-center px-4 py-2 font-semibold leading-6 text-sm shadow rounded-md text-white bg-indigo-500 hover:bg-indigo-400 transition ease-in-out duration-150 cursor-not-allowed" disabled>
+            <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-white" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            Loading...
+        </button>
+    </div>
 
+    @if (Model.Visit != null && (Model.C2.RMMODE == RemoteModality.Telephone))
     {
         <partial name="_C2T" model="@Model" />
     }
-
     else if (Model.Visit != null && (Model.C2.MODE == FormMode.InPerson) || (Model.C2.RMMODE == RemoteModality.Video))
-
     {
         <partial name="_C2" model="@Model" />
     }

--- a/src/UDS.Net.Forms/wwwroot/css/uds.net.forms.css
+++ b/src/UDS.Net.Forms/wwwroot/css/uds.net.forms.css
@@ -1,5 +1,9 @@
 
 /* Counters */
+#loadingSpinner {
+    display: none;
+}
+
 .counterreset {
     counter-reset: section;
 }

--- a/src/UDS.Net.Forms/wwwroot/css/uds.net.forms.css
+++ b/src/UDS.Net.Forms/wwwroot/css/uds.net.forms.css
@@ -1,9 +1,5 @@
 
 /* Counters */
-#loadingSpinner {
-    display: none;
-}
-
 .counterreset {
     counter-reset: section;
 }

--- a/src/UDS.Net.Forms/wwwroot/js/C2.js
+++ b/src/UDS.Net.Forms/wwwroot/js/C2.js
@@ -18,3 +18,21 @@ $(document).ready(function () {
 
   modality.addEventListener("change", handleDropdownChange);
 });
+
+document.addEventListener('turbo:before-fetch-request', function (event) {
+    if (event.target.id === 'C2') {
+        const spinner = document.getElementById('loadingSpinner');
+        if (spinner) {
+            spinner.style.display = 'block';
+        }
+    }
+});
+
+document.addEventListener('turbo:frame-load', function (event) {
+    if (event.target.id === 'C2') {
+        const spinner = document.getElementById('loadingSpinner');
+        if (spinner) {
+            spinner.style.display = 'none';  
+        }
+    }
+});


### PR DESCRIPTION
fixes #230 

Loading spinner in C2.  Happens under two conditions:

- [x] When the user selects "in-person" from the dropdown menu, the loading spinner appears while loading and disappears once it is displayed.
- [ ] When the user selects "remote" and then selects "telephone" or "video," the loading spinner appears while loading.

