### PR TITLE
Adjust the requiredIfRange value for PACDEFAGE

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.6.7</ReleaseVersion>
+		<ReleaseVersion>4.6.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
@@ -92,7 +92,7 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? CVPACDEF { get; set; }
         [Display(Name = "Age at first pacemaker and/or defibrillator implantation")]
         [RegularExpression("^(1\\d|[2-9]\\d|10\\d|110|999)$", ErrorMessage = "Valid range is 10-110 or 999")]
-        [RequiredIfRange(nameof(HRTATTACK), 1, 2, ErrorMessage = "Please specify.")]
+        [RequiredIfRange(nameof(CVPACDEF), 1, 2, ErrorMessage = "Please specify.")]
         public int? PACDEFAGE { get; set; }
         [Display(Name = "Congestive heart failure (including pulmonary edema)")]
         [RegularExpression("^([0-2]|9)$", ErrorMessage = "Valid range is 0-2 or 9")]

--- a/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
@@ -60,7 +60,7 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? HRTATTMULT { get; set; }
         [Display(Name = "Age at most recent heart attack")]
         [RegularExpression("^(1\\d|[2-9]\\d|10\\d|110|999)$", ErrorMessage = "Valid range is 10-110 or 999")]
-        [RequiredIfRange(nameof(CVPACDEF), 1, 2, ErrorMessage = "Please specify.")]
+        [RequiredIfRange(nameof(HRTATTACK), 1, 2, ErrorMessage = "Please specify.")]
         public int? HRTATTAGE { get; set; }
         [Display(Name = "Cardiac arrest (heart stopped)")]
         [RegularExpression("^([0-2]|9)$", ErrorMessage = "Valid range is 0-2 or 9")]

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.6.7</Version>
+		<Version>4.6.8</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.7</ReleaseVersion>
+		<ReleaseVersion>4.6.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>4.6.7</ReleaseVersion>
+    <ReleaseVersion>4.6.8</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.6.7</Version>
+		<Version>4.6.8</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.7</ReleaseVersion>
+		<ReleaseVersion>4.6.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.6.7</Version>
+		<Version>4.6.8</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.7</ReleaseVersion>
+		<ReleaseVersion>4.6.8</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.6.7</ReleaseVersion>
+		<ReleaseVersion>4.6.8</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Fixes: #241 

### Adjust requirement for PACDEFAGE to address validation bug in form A5D2
Adjust the requirement for PACDEFAGE from HRTATTACK to CVPACDEF. Due to the razor class library being used in UDS4, this bug also effects the UDS4 application

- [ ] Form should should now save when question 2f is 1 or 2 and a valid input for 2f1 is present OR 2f is 0 or 9 and question 2f is null
![image](https://github.com/user-attachments/assets/81e1058e-3869-474a-928d-c7940d6dc2cc)
