### PR TITLE
Add ability to persist custom medication codes

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>5.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>5.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>5.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
+++ b/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
@@ -26,9 +26,12 @@ namespace UDS.Net.Forms.Models.PageModels
         {
             get
             {
-                if (BaseForm != null)
+                if (Visit != null)
                 {
-                    return $"Participant {Visit.ParticipationId} Visit {Visit.VISITNUM} {Visit.PACKET}";
+                    if (Visit.Participation != null)
+                        return $"Participant {Visit.Participation.LegacyId} Visit {Visit.VISITNUM} {Visit.PACKET}";
+                    else
+                        return $"Participant {Visit.ParticipationId} Visit {Visit.VISITNUM} {Visit.PACKET}";
                 }
                 return "";
             }

--- a/src/UDS.Net.Forms/Models/RxNormLookupModel.cs
+++ b/src/UDS.Net.Forms/Models/RxNormLookupModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+namespace UDS.Net.Forms.Models
+{
+    public class RxNormLookupModel
+    {
+        public int Id { get; set; }
+
+        public int ResultsCount { get; set; } = 0;
+
+        public List<string> SearchResults { get; set; }
+
+        public string SearchTerm { get; set; }
+
+    }
+}
+

--- a/src/UDS.Net.Forms/Models/RxNormLookupModel.cs
+++ b/src/UDS.Net.Forms/Models/RxNormLookupModel.cs
@@ -7,7 +7,7 @@ namespace UDS.Net.Forms.Models
 
         public int ResultsCount { get; set; } = 0;
 
-        public List<string> SearchResults { get; set; }
+        public Dictionary<string, string> SearchResults { get; set; }
 
         public string SearchTerm { get; set; }
 

--- a/src/UDS.Net.Forms/Pages/Lookup/DrugCode.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/Lookup/DrugCode.cshtml.cs
@@ -40,7 +40,7 @@ namespace UDS.Net.Forms.Pages.Lookup
             {
                 Lookup.SearchTerm = searchTerm.Trim();
 
-                var lookup = await _lookupService.SearchDrugCodes(10, 1, false, searchTerm);
+                var lookup = await _lookupService.SearchDrugCodes(10, 1, searchTerm);
 
                 if (lookup != null)
                     Lookup.DrugCodes = lookup.DrugCodes.Select(c => c.ToVM()).ToList();

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -10,24 +10,37 @@
 
     <turbo-frame id="RxNorm">
         <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Back</a>
-        <form method="post">
-            <div class="@rowCSS">
-                <div>
-                    <label asp-for="@Model.RxNormLookup.SearchTerm">@Html.DisplayNameFor(m => m.RxNormLookup.SearchTerm)</label>
-                    <p class="text-gray-400"><i>Search by brand or generic name</i></p>
-                </div>
-                <div>
-                    <p class="text-sm text-gray-500" asp-description-for="RxNormLookup.SearchTerm"></p>
-                    <div class="mt-2 w-20">
-                        <input asp-for="@Model.RxNormLookup.SearchTerm" />
+
+        <div class="bg-white py-16 sm:py-24 lg:py-32">
+            <div class="mx-auto max-w-7xl px-6 lg:px-8">
+                <h2 class="max-w-xl text-3xl font-semibold tracking-tight text-balance text-gray-900 sm:text-4xl lg:col-span-7">Search RxNorm</h2>
+                <form method="post" class="w-full max-w-md lg:col-span-5 lg:pt-2">
+                    <div class="flex gap-x-4">
+                        <label asp-for="@Model.RxNormLookup.SearchTerm" class="sr-only">@Html.DisplayNameFor(m => m.RxNormLookup.SearchTerm)</label>
+                        <input asp-for="@Model.RxNormLookup.SearchTerm" placeholder="Search by drug or brand name" class="min-w-0 flex-auto rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" />
+                        <input type="hidden" asp-for="@Model.RxNormLookup.Id" />
+
+                        <input type="submit" value="Search" class="flex-none rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" />
+
                     </div>
-                    <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.RxNormLookup.SearchTerm"></span>
-                </div>
+                    <!--// Autocomplete //-->
+                    <div class="mx-auto max-w-xl transform rounded-xl bg-white p-2 ring-1 shadow-2xl ring-black/5 transition-all invisible">
+                        <ul class="-mb-2 max-h-72 scroll-py-2 overflow-y-auto py-2 text-sm text-gray-800" id="options" role="listbox">
+                            <!-- Active: "bg-indigo-600 text-white outline-hidden" -->
+                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-1" role="option" tabindex="-1">Leslie Alexander</li>
+                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-2" role="option" tabindex="-1">Michael Foster</li>
+                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-3" role="option" tabindex="-1">Dries Vincent</li>
+                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-4" role="option" tabindex="-1">Lindsay Walton</li>
+                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-5" role="option" tabindex="-1">Courtney Henry</li>
+                        </ul>
+                    </div>
+                    <!--// No results //-->
+                    <div class="bg-slate-50 px-16 py-20 text-center invisible">
+                        <h2 class="font-semibold text-slate-900">No results found</h2>
+                        <p class="mt-2 text-sm/6 text-slate-600">We can’t find anything with that term at the moment, try searching something else.</p>
+                    </div>
+                </form>
             </div>
-
-            <input type="hidden" asp-for="@Model.RxNormLookup.Id" />
-
-            <input type="submit" value="Search" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" />
-        </form>
+        </div>
     </turbo-frame>
 </div>

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -1,5 +1,12 @@
-﻿@page
+﻿@page "{id:int?}"
 @model UDS.Net.Forms.Pages.RxNorm.SearchModel
 @{
+    ViewData["Title"] = "Search RxNorm";
 }
 
+<turbo-frame id="RxNorm">
+    <a asp-page="/UDS4/A4" asp-route-id="">Back</a>
+    <form method="post">
+        <input type="submit" value="Save" />
+    </form>
+</turbo-frame>

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -2,11 +2,29 @@
 @model UDS.Net.Forms.Pages.RxNorm.SearchModel
 @{
     ViewData["Title"] = "Search RxNorm";
+    string rowCSS = "sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6";
+
 }
 
 <turbo-frame id="RxNorm">
-    <a asp-page="/UDS4/A4" asp-route-id="">Back</a>
+    <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id">Back</a>
     <form method="post">
-        <input type="submit" value="Save" />
+        <div class="@rowCSS">
+            <div>
+                <label asp-for="@Model.RxNormLookup.SearchTerm">@Html.DisplayNameFor(m => m.RxNormLookup.SearchTerm)</label>
+                <p class="text-gray-400"><i>Search by brand or generic name</i></p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500" asp-description-for="RxNormLookup.SearchTerm"></p>
+                <div class="mt-2 w-20">
+                    <input asp-for="@Model.RxNormLookup.SearchTerm" />
+                </div>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.RxNormLookup.SearchTerm"></span>
+            </div>
+        </div>
+
+        <input type="hidden" asp-for="@Model.RxNormLookup.Id" />
+
+        <input type="submit" value="Search" />
     </form>
 </turbo-frame>

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -12,7 +12,7 @@
         <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Back</a>
 
         <div class="bg-white py-16 sm:py-24 lg:py-32">
-            <div data-controller="autocomplete" class="mx-auto max-w-7xl px-6 lg:px-8">
+            <div data-controller="autocomplete rxNormDisplayNames" data-action="autocomplete:newSearch->rxNormDisplayNames#fetchData" class="mx-auto max-w-7xl px-6 lg:px-8">
                 <h2 class="max-w-xl text-3xl font-semibold tracking-tight text-balance text-gray-900 sm:text-4xl lg:col-span-7">Search RxNorm</h2>
                 <form method="post" class="w-full max-w-md lg:col-span-5 lg:pt-2">
                     <div class="flex gap-x-4">
@@ -23,7 +23,7 @@
                         <input type="submit" value="Search" class="flex-none rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" />
                     </div>
                     <!--// Autocomplete //-->
-                    <div data-controller="rxNormDisplayNames" data-autocomplete-target="list" class="mx-auto max-w-xl transform rounded-xl bg-white p-2 ring-1 shadow-2xl ring-black/5 transition-all">
+                    <div data-autocomplete-target="list" class="mx-auto max-w-xl transform rounded-xl bg-white p-2 ring-1 shadow-2xl ring-black/5 transition-all">
                         <ul data-rxNormDisplayNames-target="list" class="-mb-2 max-h-72 scroll-py-2 overflow-y-auto py-2 text-sm text-gray-800" id="options" role="listbox">
                             <!-- Active: "bg-indigo-600 text-white outline-hidden" -->
                             <li data-autocomplete-target="item" data-action="click->autocomplete#setSearchBox" class="cursor-default hover:bg-indigo-600 hover:text-white rounded-md px-4 py-2 select-none" id="option-1" role="option" tabindex="-1">Leslie Alexander</li>

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -1,0 +1,5 @@
+﻿@page
+@model UDS.Net.Forms.Pages.RxNorm.SearchModel
+@{
+}
+

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -12,30 +12,25 @@
         <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Back</a>
 
         <div class="bg-white py-16 sm:py-24 lg:py-32">
-            <div class="mx-auto max-w-7xl px-6 lg:px-8">
+            <div data-controller="autocomplete" class="mx-auto max-w-7xl px-6 lg:px-8">
                 <h2 class="max-w-xl text-3xl font-semibold tracking-tight text-balance text-gray-900 sm:text-4xl lg:col-span-7">Search RxNorm</h2>
                 <form method="post" class="w-full max-w-md lg:col-span-5 lg:pt-2">
                     <div class="flex gap-x-4">
                         <label asp-for="@Model.RxNormLookup.SearchTerm" class="sr-only">@Html.DisplayNameFor(m => m.RxNormLookup.SearchTerm)</label>
-                        <input asp-for="@Model.RxNormLookup.SearchTerm" placeholder="Search by drug or brand name" class="min-w-0 flex-auto rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6" />
+                        <input data-autocomplete-target="searchBox" data-action="click->autocomplete#showList input->autocomplete#filterList" asp-for="@Model.RxNormLookup.SearchTerm" placeholder="Search by drug or brand name" class="min-w-0 flex-auto rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-1 focus:-outline-offset-1 focus:outline-indigo-600 sm:text-sm/6" />
                         <input type="hidden" asp-for="@Model.RxNormLookup.Id" />
 
                         <input type="submit" value="Search" class="flex-none rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" />
-
                     </div>
                     <!--// Autocomplete //-->
-                    <div class="mx-auto max-w-xl transform rounded-xl bg-white p-2 ring-1 shadow-2xl ring-black/5 transition-all invisible">
-                        <ul class="-mb-2 max-h-72 scroll-py-2 overflow-y-auto py-2 text-sm text-gray-800" id="options" role="listbox">
+                    <div data-controller="rxNormDisplayNames" data-autocomplete-target="list" class="mx-auto max-w-xl transform rounded-xl bg-white p-2 ring-1 shadow-2xl ring-black/5 transition-all">
+                        <ul data-rxNormDisplayNames-target="list" class="-mb-2 max-h-72 scroll-py-2 overflow-y-auto py-2 text-sm text-gray-800" id="options" role="listbox">
                             <!-- Active: "bg-indigo-600 text-white outline-hidden" -->
-                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-1" role="option" tabindex="-1">Leslie Alexander</li>
-                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-2" role="option" tabindex="-1">Michael Foster</li>
-                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-3" role="option" tabindex="-1">Dries Vincent</li>
-                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-4" role="option" tabindex="-1">Lindsay Walton</li>
-                            <li class="cursor-default rounded-md px-4 py-2 select-none" id="option-5" role="option" tabindex="-1">Courtney Henry</li>
+                            <li data-autocomplete-target="item" data-action="click->autocomplete#setSearchBox" class="cursor-default hover:bg-indigo-600 hover:text-white rounded-md px-4 py-2 select-none" id="option-1" role="option" tabindex="-1">Leslie Alexander</li>
                         </ul>
                     </div>
                     <!--// No results //-->
-                    <div class="bg-slate-50 px-16 py-20 text-center invisible">
+                    <div data-autocomplete-target="noResults" class="bg-slate-50 px-16 py-20 text-center hidden">
                         <h2 class="font-semibold text-slate-900">No results found</h2>
                         <p class="mt-2 text-sm/6 text-slate-600">We can’t find anything with that term at the moment, try searching something else.</p>
                     </div>

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -12,7 +12,7 @@
         <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Back</a>
 
         <div class="bg-white py-16 sm:py-24 lg:py-32">
-            <div data-controller="autocomplete rxNormDisplayNames" data-action="autocomplete:newSearch->rxNormDisplayNames#fetchData" class="mx-auto max-w-7xl px-6 lg:px-8">
+            <div data-controller="autocomplete rxNormDisplayNames" data-action="autocomplete:newSearch->rxNormDisplayNames#fetchData" data-rxNormDisplayNames-fetchedLetters-value="" class="mx-auto max-w-7xl px-6 lg:px-8">
                 <h2 class="max-w-xl text-3xl font-semibold tracking-tight text-balance text-gray-900 sm:text-4xl lg:col-span-7">Search RxNorm</h2>
                 <form method="post" class="w-full max-w-md lg:col-span-5 lg:pt-2">
                     <div class="flex gap-x-4">

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml
@@ -6,25 +6,28 @@
 
 }
 
-<turbo-frame id="RxNorm">
-    <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id">Back</a>
-    <form method="post">
-        <div class="@rowCSS">
-            <div>
-                <label asp-for="@Model.RxNormLookup.SearchTerm">@Html.DisplayNameFor(m => m.RxNormLookup.SearchTerm)</label>
-                <p class="text-gray-400"><i>Search by brand or generic name</i></p>
-            </div>
-            <div>
-                <p class="text-sm text-gray-500" asp-description-for="RxNormLookup.SearchTerm"></p>
-                <div class="mt-2 w-20">
-                    <input asp-for="@Model.RxNormLookup.SearchTerm" />
+<div class="px-2 py-5">
+
+    <turbo-frame id="RxNorm">
+        <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Back</a>
+        <form method="post">
+            <div class="@rowCSS">
+                <div>
+                    <label asp-for="@Model.RxNormLookup.SearchTerm">@Html.DisplayNameFor(m => m.RxNormLookup.SearchTerm)</label>
+                    <p class="text-gray-400"><i>Search by brand or generic name</i></p>
                 </div>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.RxNormLookup.SearchTerm"></span>
+                <div>
+                    <p class="text-sm text-gray-500" asp-description-for="RxNormLookup.SearchTerm"></p>
+                    <div class="mt-2 w-20">
+                        <input asp-for="@Model.RxNormLookup.SearchTerm" />
+                    </div>
+                    <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.RxNormLookup.SearchTerm"></span>
+                </div>
             </div>
-        </div>
 
-        <input type="hidden" asp-for="@Model.RxNormLookup.Id" />
+            <input type="hidden" asp-for="@Model.RxNormLookup.Id" />
 
-        <input type="submit" value="Search" />
-    </form>
-</turbo-frame>
+            <input type="submit" value="Search" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" />
+        </form>
+    </turbo-frame>
+</div>

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
@@ -40,7 +40,6 @@ namespace UDS.Net.Forms.Pages.RxNorm
 
             try
             {
-
                 var results = await _lookupService.LookupRxNormApproximateMatches(RxNormLookup.SearchTerm);
 
                 var count = results.Where(t => t.Name.ToLower().Contains(RxNormLookup.SearchTerm.ToLower())).Count();

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
@@ -4,21 +4,21 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using rxNorm.Net.Api.Wrapper;
 using UDS.Net.Forms.Models;
+using UDS.Net.Services;
 
 namespace UDS.Net.Forms.Pages.RxNorm
 {
     public class SearchModel : PageModel
     {
-        protected readonly IRxNormClient _rxNormClient;
+        protected readonly ILookupService _lookupService;
 
         [BindProperty]
         public RxNormLookupModel RxNormLookup { get; set; } = default!;
 
-        public SearchModel(IRxNormClient rxNormClient)
+        public SearchModel(ILookupService lookupService)
         {
-            _rxNormClient = rxNormClient;
+            _lookupService = lookupService;
         }
 
         public async Task<IActionResult> OnGetAsync(int? id)
@@ -38,25 +38,28 @@ namespace UDS.Net.Forms.Pages.RxNorm
                 return Page();
             }
 
-            var results = await _rxNormClient.SearchDisplayTermsAsync(RxNormLookup.SearchTerm);
-
-            if (results != null)
+            try
             {
-                RxNormLookup.ResultsCount = results.Count();
-                if (RxNormLookup.ResultsCount > 0)
-                    RxNormLookup.SearchResults = results.ToList();
+
+                var results = await _lookupService.LookupRxNormApproximateMatches(RxNormLookup.SearchTerm);
+
+                var count = results.Where(t => t.Name.ToLower().Contains(RxNormLookup.SearchTerm.ToLower())).Count();
+
+                if (count > 0)
+                {
+                    return RedirectToPage("/RxNorm/Select", new { Id = RxNormLookup.Id, SearchTerm = RxNormLookup.SearchTerm });
+                }
                 else
                 {
                     ModelState.AddModelError("RxNormLookup.SearchTerm", "No results found.");
                     return Page();
                 }
             }
-            else
+            catch (Exception ex)
             {
                 ModelState.AddModelError("RxNormLookup.SearchTerm", "Trouble accessing RxNorm web api. Please use RxNav: https://lhncbc.nlm.nih.gov/RxNav/ to find RxCUI and submit ticket to DMS to update packet.");
                 return Page();
             }
-            return RedirectToPage("/RxNorm/Select", new { Id = RxNormLookup.Id, SearchTerm = RxNormLookup.SearchTerm });
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
@@ -9,8 +9,20 @@ namespace UDS.Net.Forms.Pages.RxNorm
 {
     public class SearchModel : PageModel
     {
-        public void OnGet()
+        [BindProperty]
+        public int Id { get; set; } = 0;
+
+        public async Task<IActionResult> OnGetAsync(int? id)
         {
+            if (id.HasValue)
+                Id = id.Value;
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(int id)
+        {
+            return Page();
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
@@ -4,25 +4,59 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using rxNorm.Net.Api.Wrapper;
+using UDS.Net.Forms.Models;
 
 namespace UDS.Net.Forms.Pages.RxNorm
 {
     public class SearchModel : PageModel
     {
+        protected readonly IRxNormClient _rxNormClient;
+
         [BindProperty]
-        public int Id { get; set; } = 0;
+        public RxNormLookupModel RxNormLookup { get; set; } = default!;
+
+        public SearchModel(IRxNormClient rxNormClient)
+        {
+            _rxNormClient = rxNormClient;
+        }
 
         public async Task<IActionResult> OnGetAsync(int? id)
         {
+            RxNormLookup = new RxNormLookupModel();
             if (id.HasValue)
-                Id = id.Value;
+                RxNormLookup.Id = id.Value;
 
             return Page();
         }
 
         public async Task<IActionResult> OnPostAsync(int id)
         {
-            return Page();
+            if (String.IsNullOrWhiteSpace(RxNormLookup.SearchTerm))
+            {
+                ModelState.AddModelError("RxNormLookup.SearchTerm", "Must include a search term.");
+                return Page();
+            }
+
+            var results = await _rxNormClient.SearchDisplayTermsAsync(RxNormLookup.SearchTerm);
+
+            if (results != null)
+            {
+                RxNormLookup.ResultsCount = results.Count();
+                if (RxNormLookup.ResultsCount > 0)
+                    RxNormLookup.SearchResults = results.ToList();
+                else
+                {
+                    ModelState.AddModelError("RxNormLookup.SearchTerm", "No results found.");
+                    return Page();
+                }
+            }
+            else
+            {
+                ModelState.AddModelError("RxNormLookup.SearchTerm", "Trouble accessing RxNorm web api. Please use RxNav: https://lhncbc.nlm.nih.gov/RxNav/ to find RxCUI and submit ticket to DMS to update packet.");
+                return Page();
+            }
+            return RedirectToPage("/RxNorm/Select", new { Id = RxNormLookup.Id, SearchTerm = RxNormLookup.SearchTerm });
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Search.cshtml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace UDS.Net.Forms.Pages.RxNorm
+{
+    public class SearchModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
@@ -1,4 +1,4 @@
-﻿@page "{id:int?}"
+﻿@page
 @model UDS.Net.Forms.Pages.RxNorm.SelectModel
 @{
     ViewData["Title"] = "Select a medication";

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
@@ -1,5 +1,6 @@
-﻿@page
+﻿@page "{id:int?}"
 @model UDS.Net.Forms.Pages.RxNorm.SelectModel
 @{
+    ViewData["Title"] = "Select a medication";
 }
 

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
@@ -4,3 +4,22 @@
     ViewData["Title"] = "Select a medication";
 }
 
+@if (Model.RxNormLookup.SearchResults != null)
+{
+    <table>
+        <tbody>
+            @foreach (var result in Model.RxNormLookup.SearchResults)
+            {
+                <tr>
+                    <td>
+                        <form method="post" asp-route-id="@Model.RxNormLookup.Id">
+                            @result.Key
+                            <input type="hidden" name="rxCUI" value="@result.Value" />
+                            <input type="submit" />
+                        </form>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
@@ -4,22 +4,34 @@
     ViewData["Title"] = "Select a medication";
 }
 
-@if (Model.RxNormLookup.SearchResults != null)
-{
-    <table>
-        <tbody>
-            @foreach (var result in Model.RxNormLookup.SearchResults)
-            {
-                <tr>
-                    <td>
-                        <form method="post" asp-route-id="@Model.RxNormLookup.Id">
-                            @result.Key
+<div class="px-2 py-5">
+    <a asp-page="/UDS4/A4" asp-route-id="@Model.RxNormLookup.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Back</a>
+
+    @if (Model.RxNormLookup.SearchResults != null)
+    {
+
+        @foreach (var result in Model.RxNormLookup.SearchResults)
+        {
+            <div class="space-y-3">
+
+                <form method="post" asp-route-id="@Model.RxNormLookup.Id" class="rounded-md bg-white px-6 py-4 shadow-sm">
+                    <div class="md:flex md:items-center md:justify-between gap-x-6 py-5">
+                        <div class="min-w-0">
+                            <p class="text-sm/6 text-gray-900">
+                                @result.Key
+                            </p>
                             <input type="hidden" name="rxCUI" value="@result.Value" />
-                            <input type="submit" />
-                        </form>
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
-}
+                            <input type="hidden" name="drugName" value="@result.Key" />
+                            <input type="hidden" asp-for="@Model.RxNormLookup.Id" />
+                        </div>
+                        <div class="flex flex-none items-center gap-x-4">
+                            <button type="button" class="text-sm/6 font-semibold text-gray-900" disabled>@result.Value</button>
+                            <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Select</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        }
+
+    }
+</div>

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml
@@ -1,0 +1,5 @@
+﻿@page
+@model UDS.Net.Forms.Pages.RxNorm.SelectModel
+@{
+}
+

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
@@ -82,13 +82,13 @@ namespace UDS.Net.Forms.Pages.RxNorm
                 if (lookup.TotalResultsCount > 0 && lookup.DrugCodes != null && lookup.DrugCodes.Count() > 0)
                 {
                     // Drug code already exists in local lookup
-                    lookup.DrugCodes.FirstOrDefault();
-                    newDrug.RxNormId = rxCUI;
+                    var existing = lookup.DrugCodes.FirstOrDefault();
+                    newDrug.RxNormId = existing.RxNormId;
                 }
                 else
                 {
                     // Drug code isn't in local db, so we need to add it before assigning to A4
-                    await _lookupService.AddDrugCodeToLookup(new Services.LookupModels.DrugCode
+                    var added = await _lookupService.AddDrugCodeToLookup(new Services.LookupModels.DrugCode
                     {
                         RxNormId = rxCUI,
                         DrugName = drugName,
@@ -96,6 +96,7 @@ namespace UDS.Net.Forms.Pages.RxNorm
                         IsOverTheCounter = false,
                         IsPopular = false
                     });
+                    newDrug.RxNormId = added.RxNormId;
                 }
 
                 var visit = await _visitService.GetByIdWithForm(User.Identity.IsAuthenticated ? User.Identity.Name : "username", id, "A4");
@@ -104,6 +105,7 @@ namespace UDS.Net.Forms.Pages.RxNorm
                     var form = visit.Forms.FirstOrDefault(f => f.Kind == "A4");
                     if (form != null)
                     {
+                        form.Status = Services.Enums.FormStatus.InProgress;
                         var fields = (A4GFormFields)form.Fields;
                         if (fields != null)
                         {

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace UDS.Net.Forms.Pages.RxNorm
+{
+    public class SelectModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
@@ -9,8 +9,10 @@ namespace UDS.Net.Forms.Pages.RxNorm
 {
     public class SelectModel : PageModel
     {
-        public void OnGet()
+        public async Task<IActionResult> OnGet(int id, string searchTerm)
         {
+            var test = "";
+            return Page();
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
@@ -4,15 +4,81 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using UDS.Net.Forms.Extensions;
+using UDS.Net.Forms.Models;
+using UDS.Net.Forms.Models.UDS4;
+using UDS.Net.Services;
+using UDS.Net.Services.DomainModels.Forms;
 
 namespace UDS.Net.Forms.Pages.RxNorm
 {
     public class SelectModel : PageModel
     {
+        protected readonly ILookupService _lookupService;
+        protected readonly IVisitService _visitService;
+
+        public RxNormLookupModel RxNormLookup { get; set; } = default!;
+
+        public SelectModel(ILookupService lookupService, IVisitService visitService)
+        {
+            _lookupService = lookupService;
+            _visitService = visitService;
+        }
+
         public async Task<IActionResult> OnGet(int id, string searchTerm)
         {
-            var test = "";
+            RxNormLookup = new RxNormLookupModel()
+            {
+                Id = id,
+                SearchTerm = searchTerm
+            };
+
+            if (String.IsNullOrWhiteSpace(searchTerm))
+                return RedirectToPage("/RxNorm/Search", new { Id = id });
+
+            var results = await _lookupService.LookupRxNormApproximateMatches(searchTerm);
+
+            // WORKAROUND simplify results (rx norm has duplicate names)
+            foreach (var result in results)
+            {
+                if (!RxNormLookup.SearchResults.Where(s => s.Key == result.Name).Any())
+                    RxNormLookup.SearchResults.Add(result.Name, result.RxCUI);
+            }
+
             return Page();
+        }
+
+        public async Task<IActionResult> OnPost(int id, string rxCUI)
+        {
+            if (!String.IsNullOrWhiteSpace(rxCUI))
+            {
+                var visit = await _visitService.GetByIdWithForm(User.Identity.IsAuthenticated ? User.Identity.Name : "username", id, "A4");
+                if (visit != null)
+                {
+                    var form = visit.Forms.FirstOrDefault(f => f.Kind == "A4");
+                    if (form != null)
+                    {
+                        var fields = (A4GFormFields)form.Fields;
+                        if (fields != null)
+                        {
+                            if (!fields.A4Ds.Where(a => a.RxNormId == rxCUI).Any())
+                            {
+                                fields.ANYMEDS = 1;
+                                fields.A4Ds.Add(new A4DFormFields
+                                {
+                                    RxNormId = rxCUI,
+                                    CreatedAt = DateTime.Now,
+                                    CreatedBy = User.Identity.Name
+                                });
+                                await _visitService.UpdateForm(User.Identity.IsAuthenticated ? User.Identity.Name : "username", visit, "A4");
+                            }
+                        }
+                    }
+
+                }
+            }
+
+            return RedirectToPage("/UDS4/A4", new { Id = id });
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/RxNorm/Select.cshtml.cs
@@ -30,7 +30,8 @@ namespace UDS.Net.Forms.Pages.RxNorm
             RxNormLookup = new RxNormLookupModel()
             {
                 Id = id,
-                SearchTerm = searchTerm
+                SearchTerm = searchTerm,
+                SearchResults = new Dictionary<string, string>()
             };
 
             if (String.IsNullOrWhiteSpace(searchTerm))

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -100,7 +100,15 @@
             </div>
         }
 
-
+        <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
+            <div>
+                <p><strong>If a medication is not listed above</strong></p>
+                <p>Use the "Add" button to search for a valid RXNorm code by drug or brand name.</p>
+            </div>
+            <div>
+                <a asp-page="/RxNorm/Search">Add</a>
+            </div>
+        </div>
         <div class="sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
             <div>
                 @if (Model.CustomDrugCodes != null || Model.CustomDrugCodes.Count() == 0)

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -101,6 +101,9 @@
         }
 
         <!--// Custom medications //-->
+        <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+            <p>Custom medications</p>
+        </div>
         <div class="sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
             <div>
                 @if (Model.CustomDrugCodes != null || Model.CustomDrugCodes.Count() == 0)

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -13,279 +13,280 @@
 <p class="mt-1 text-sm text-gray-500">
     INSTRUCTIONS: This form is to be completed by the clinician or ADRC staff. The purpose of this form is to record all prescription medications taken by the participant within the <strong>two weeks before the current visit.</strong> If the participant is receiving any treatments known to significantly impact Alzheimer disease and related dementias (ADRD) biomarkers as part of their clinical care at the time of clinical assessment (e.g., they are receiving aducanumab infusions), the treatment should be included on both this form and the A4a ADRD–Specific Treatments form. For prescription medications not listed here, please follow the instructions at the end of this form. OTC (non-prescription) medications need not be reported; however, a short list of medications that could be either prescription or OTC follows the prescription list. For additional clarification and examples, see <guidebook kind="@Model.Visit.PACKET"></guidebook> for <strong>Form A4.</strong>
 </p>
-<div>
-    <p class="mt-1 text-sm text-gray-500">
-        INSTRUCTIONS: This form is to be completed by the clinician or ADRC staff. The purpose of this form is to record all prescription medications taken by the participant within the <strong>two weeks before the current visit.</strong> If the participant is receiving any treatments known to significantly impact Alzheimer disease and related dementias (ADRD) biomarkers as part of their clinical care at the time of clinical assessment (e.g., they are receiving aducanumab infusions), the treatment should be included on both this form and the A4a ADRD–Specific Treatments form. For prescription medications not listed here, please follow the instructions at the end of this form. OTC (non-prescription) medications need not be reported; however, a short list of medications that could be either prescription or OTC follows the prescription list. For additional clarification and examples, see <guidebook kind="@Model.Visit.PACKET"></guidebook> for <strong>Form A4.</strong>
-        <div>
-            <div class="mt-10 space-y-8 border-b border-gray-900/10 pb-12 sm:space-y-0 sm:divide-y sm:divide-gray-900/10 sm:border-t sm:pb-0">
-                <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A4.ANYMEDS"><span class="counter"></span> @Html.DisplayNameFor(m => m.A4.ANYMEDS)</label>
-                    <div class="mt-4 sm:col-span-2 sm:mt-0">
-                        <p class="text-sm text-gray-500" asp-description-for="@Model.A4.ANYMEDS"></p>
-                        <radio-button-group id="@Html.IdFor(m => m.A4.ANYMEDS)" for="@Model.A4.ANYMEDS" items="Model.MedicationsWithinLastTwoWeeksListItems"></radio-button-group>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="A4.ANYMEDS"></span>
-                    </div>
-                </div>
 
-                <!-- Popular Drug Codes -->
-                <!-- Left Column Popular Drug Codes -->
-                <div class="grid lg:grid-cols-2 sm:grid-cols-1">
-                    <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        @if (Model.PopularDrugCodes != null && Model.PopularDrugCodes.Count() > 0)
-                        {
-                            for (int i = 0; i < defaultMedsMedian; i++)
-                            {
-                                var drugCode = Model.PopularDrugCodes[i];
-                                var displayName = drugCode.DrugName;
+<div class="mt-10 space-y-8 border-b border-gray-900/10 pb-12 sm:space-y-0 sm:divide-y sm:divide-gray-900/10 sm:border-t sm:pb-0">
+    <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
+        <label asp-for="A4.ANYMEDS"><span class="counter"></span> @Html.DisplayNameFor(m => m.A4.ANYMEDS)</label>
+        <div class="mt-4 sm:col-span-2 sm:mt-0">
+            <p class="text-sm text-gray-500" asp-description-for="@Model.A4.ANYMEDS"></p>
+            <radio-button-group id="@Html.IdFor(m => m.A4.ANYMEDS)" for="@Model.A4.ANYMEDS" items="Model.MedicationsWithinLastTwoWeeksListItems"></radio-button-group>
+            <span class="mt-2 text-sm text-red-600" asp-validation-for="A4.ANYMEDS"></span>
+        </div>
+    </div>
 
-                                if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
-
-                                {
-                                    displayName += " (" + drugCode.BrandName + ")";
-                                }
-                                <div>
-                                    <fieldset>
-                                        <div class="space-y-5">
-                                            <div class="relative flex items-start">
-                                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                                <div class="flex h-6 items-center">
-                                                    <input asp-for="PopularDrugCodes[i].Id" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[i].RxNormId" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[i].DrugName" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[i].BrandName" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[i].IsOverTheCounter" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[i].IsPopular" type="hidden" />
-                                                    <input asp-for="@Model.PopularDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" />
-                                                </div>
-                                                <div class="ml-3 text-sm leading-6">
-                                                    <label for="@Html.IdFor(m => m.PopularDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.PopularDrugCodes[i].RxNormId</span></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                            }
-                        }
-                    </div>
-
-                    <!-- Right Column Popular Drug Codes -->
-                    <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        @if (Model.PopularDrugCodes != null && Model.PopularDrugCodes.Count() > 0)
-                        {
-                            for (int j = defaultMedsMedian; j < Model.PopularDrugCodes.Count; j++)
-                            {
-                                var drugCode = Model.PopularDrugCodes[j];
-                                var displayName = drugCode.DrugName;
-
-                                if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
-                                {
-                                    displayName += " (" + drugCode.BrandName + ")";
-                                }
-                                <div>
-                                    <fieldset>
-                                        <div class="space-y-5">
-                                            <div class="relative flex items-start">
-                                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                                <div class="flex h-6 items-center">
-                                                    <input asp-for="PopularDrugCodes[j].Id" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[j].RxNormId" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[j].DrugName" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[j].BrandName" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[j].IsOverTheCounter" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[j].IsPopular" type="hidden" />
-                                                    <input asp-for="PopularDrugCodes[j].IsSelected" type="checkbox" class="@checkboxCSS" />
-                                                </div>
-                                                <div class="ml-3 text-sm leading-6">
-                                                    <label for="@Html.IdFor(m => m.PopularDrugCodes[j].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.PopularDrugCodes[j].RxNormId</span></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                            }
-                        }
-                    </div>
-                </div>
-
-                @if (Model.OTCDrugCodes != null || Model.OTCDrugCodes.Count() == 0)
+    <!-- Checkboxes for popular, otc, and custom drug codes-->
+    <div>
+        <!-- Popular Drug Codes -->
+        <div class="grid lg:grid-cols-2 sm:grid-cols-1">
+            <!-- Left Column Popular Drug Codes -->
+            <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                @if (Model.PopularDrugCodes != null && Model.PopularDrugCodes.Count() > 0)
                 {
-                    <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        <p>Commonly reported medications that may be purchased over the counter (but that may also be prescription)</p>
-                    </div>
+                    for (int i = 0; i < defaultMedsMedian; i++)
+                    {
+                        var drugCode = Model.PopularDrugCodes[i];
+                        var displayName = drugCode.DrugName;
+
+                        if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
+
+                        {
+                            displayName += " (" + drugCode.BrandName + ")";
+                        }
+                        <div>
+                            <fieldset>
+                                <div class="space-y-5">
+                                    <div class="relative flex items-start">
+                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                        <div class="flex h-6 items-center">
+                                            <input asp-for="PopularDrugCodes[i].Id" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[i].RxNormId" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[i].DrugName" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[i].BrandName" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[i].IsOverTheCounter" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[i].IsPopular" type="hidden" />
+                                            <input asp-for="@Model.PopularDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" />
+                                        </div>
+                                        <div class="ml-3 text-sm leading-6">
+                                            <label for="@Html.IdFor(m => m.PopularDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.PopularDrugCodes[i].RxNormId</span></label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                    }
                 }
+            </div>
 
-                <!-- OTC Drug Codes -->
-                <!-- Left Column OTC Drug Codes -->
-                <div class="grid lg:grid-cols-2 sm:grid-cols-2">
-                    <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        @if (Model.OTCDrugCodes != null && Model.OTCDrugCodes.Count() > 0)
+            <!-- Right Column Popular Drug Codes -->
+            <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                @if (Model.PopularDrugCodes != null && Model.PopularDrugCodes.Count() > 0)
+                {
+                    for (int j = defaultMedsMedian; j < Model.PopularDrugCodes.Count; j++)
+                    {
+                        var drugCode = Model.PopularDrugCodes[j];
+                        var displayName = drugCode.DrugName;
+
+                        if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
                         {
-                            for (int i = 0; i < defaultMedsMedianOTC; i++)
-                            {
-                                var drugCode = Model.OTCDrugCodes[i];
-                                var displayName = drugCode.DrugName;
-
-                                if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
-                                {
-                                    displayName += " (" + drugCode.BrandName + ")";
-                                }
-                                <div>
-                                    <fieldset>
-                                        <div class="space-y-5">
-                                            <div class="relative flex items-start">
-                                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                                <div class="flex h-6 items-center">
-                                                    <input asp-for="OTCDrugCodes[i].Id" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[i].RxNormId" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[i].DrugName" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[i].BrandName" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[i].IsOverTheCounter" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[i].IsPopular" type="hidden" />
-                                                    <input asp-for="@Model.OTCDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" />
-                                                </div>
-                                                <div class="ml-3 text-sm leading-6">
-                                                    <label for="@Html.IdFor(m => m.OTCDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.OTCDrugCodes[i].RxNormId</span></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                            }
+                            displayName += " (" + drugCode.BrandName + ")";
                         }
-                    </div>
-
-                    <!-- Right Column OTC Drug Codes -->
-                    <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        @if (Model.OTCDrugCodes != null && Model.OTCDrugCodes.Count() > 0)
-                        {
-                            for (int j = defaultMedsMedianOTC; j < Model.OTCDrugCodes.Count; j++)
-                            {
-                                var drugCode = Model.OTCDrugCodes[j];
-                                var displayName = drugCode.DrugName;
-
-                                if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
-                                {
-                                    displayName += " (" + drugCode.BrandName + ")";
-                                }
-                                <div>
-                                    <fieldset>
-                                        <div class="space-y-5">
-                                            <div class="relative flex items-start">
-                                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                                <div class="flex h-6 items-center">
-                                                    <input asp-for="OTCDrugCodes[j].Id" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[j].RxNormId" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[j].DrugName" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[j].BrandName" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[j].IsOverTheCounter" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[j].IsPopular" type="hidden" />
-                                                    <input asp-for="OTCDrugCodes[j].IsSelected" type="checkbox" class="@checkboxCSS" />
-                                                </div>
-                                                <div class="ml-3 text-sm leading-6">
-                                                    <label for="@Html.IdFor(m => m.OTCDrugCodes[j].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.OTCDrugCodes[j].RxNormId</span></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                            }
-                        }
-                    </div>
-                </div>
-
-                <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
-                    <p>Custom medications</p>
-                    <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
                         <div>
-                            <p><strong>If a medication is not listed</strong></p>
-                            <p>Use the "Add" button to search for a valid RXNorm code by drug or brand name.</p>
+                            <fieldset>
+                                <div class="space-y-5">
+                                    <div class="relative flex items-start">
+                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                        <div class="flex h-6 items-center">
+                                            <input asp-for="PopularDrugCodes[j].Id" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[j].RxNormId" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[j].DrugName" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[j].BrandName" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[j].IsOverTheCounter" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[j].IsPopular" type="hidden" />
+                                            <input asp-for="PopularDrugCodes[j].IsSelected" type="checkbox" class="@checkboxCSS" />
+                                        </div>
+                                        <div class="ml-3 text-sm leading-6">
+                                            <label for="@Html.IdFor(m => m.PopularDrugCodes[j].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.PopularDrugCodes[j].RxNormId</span></label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
                         </div>
+                    }
+                }
+            </div>
+        </div>
+
+        @if (Model.OTCDrugCodes != null || Model.OTCDrugCodes.Count() == 0)
+        {
+            <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                <p>Commonly reported medications that may be purchased over the counter (but that may also be prescription)</p>
+            </div>
+        }
+
+        <!-- OTC Drug Codes -->
+        <div class="grid lg:grid-cols-2 sm:grid-cols-2">
+            <!-- Left Column OTC Drug Codes -->
+            <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                @if (Model.OTCDrugCodes != null && Model.OTCDrugCodes.Count() > 0)
+                {
+                    for (int i = 0; i < defaultMedsMedianOTC; i++)
+                    {
+                        var drugCode = Model.OTCDrugCodes[i];
+                        var displayName = drugCode.DrugName;
+
+                        if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
+                        {
+                            displayName += " (" + drugCode.BrandName + ")";
+                        }
                         <div>
-                            <a asp-page="/RxNorm/Search" asp-route-id="@Model.Visit.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Add</a>
+                            <fieldset>
+                                <div class="space-y-5">
+                                    <div class="relative flex items-start">
+                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                        <div class="flex h-6 items-center">
+                                            <input asp-for="OTCDrugCodes[i].Id" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[i].RxNormId" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[i].DrugName" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[i].BrandName" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[i].IsOverTheCounter" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[i].IsPopular" type="hidden" />
+                                            <input asp-for="@Model.OTCDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" />
+                                        </div>
+                                        <div class="ml-3 text-sm leading-6">
+                                            <label for="@Html.IdFor(m => m.OTCDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.OTCDrugCodes[i].RxNormId</span></label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
                         </div>
-                    </div>
+                    }
+                }
+            </div>
+
+            <!-- Right Column OTC Drug Codes -->
+            <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                @if (Model.OTCDrugCodes != null && Model.OTCDrugCodes.Count() > 0)
+                {
+                    for (int j = defaultMedsMedianOTC; j < Model.OTCDrugCodes.Count; j++)
+                    {
+                        var drugCode = Model.OTCDrugCodes[j];
+                        var displayName = drugCode.DrugName;
+
+                        if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
+                        {
+                            displayName += " (" + drugCode.BrandName + ")";
+                        }
+                        <div>
+                            <fieldset>
+                                <div class="space-y-5">
+                                    <div class="relative flex items-start">
+                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                        <div class="flex h-6 items-center">
+                                            <input asp-for="OTCDrugCodes[j].Id" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[j].RxNormId" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[j].DrugName" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[j].BrandName" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[j].IsOverTheCounter" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[j].IsPopular" type="hidden" />
+                                            <input asp-for="OTCDrugCodes[j].IsSelected" type="checkbox" class="@checkboxCSS" />
+                                        </div>
+                                        <div class="ml-3 text-sm leading-6">
+                                            <label for="@Html.IdFor(m => m.OTCDrugCodes[j].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.OTCDrugCodes[j].RxNormId</span></label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+
+        <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
+            <p>Custom medications</p>
+            <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                <div>
+                    <p><strong>If a medication is not listed</strong></p>
+                    <p>Use the "Add" button to search for a valid RXNorm code by drug or brand name.</p>
                 </div>
-                <!-- Custom Drug Codes -->
-                <!-- Left  Column Custom Drug Codes -->
-                <div class="grid lg:grid-cols-2 sm:grid-cols-2">
-                    <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        @if (Model.CustomDrugCodes != null && Model.CustomDrugCodes.Count() > 0)
-                        {
-                            for (int i = 0; i < defaultMedsMedianCustom; i++)
-                            {
-                                var drugCode = Model.CustomDrugCodes[i];
-                                var displayName = drugCode.DrugName;
-
-                                if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
-                                {
-                                    displayName += " (" + drugCode.BrandName + ")";
-                                }
-                                <div>
-                                    <fieldset>
-                                        <div class="space-y-5">
-                                            <div class="relative flex items-start">
-                                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                                <div class="flex h-6 items-center">
-                                                    <input asp-for="CustomDrugCodes[i].Id" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].RxNormId" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].DrugName" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].BrandName" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].IsOverTheCounter" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].IsPopular" type="hidden" />
-                                                    <input asp-for="@Model.CustomDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" />
-                                                </div>
-                                                <div class="ml-3 text-sm leading-6">
-                                                    <label for="@Html.IdFor(m => m.CustomDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.CustomDrugCodes[i].RxNormId</span></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                            }
-                        }
-                    </div>
-
-                    <!-- Right  Column Custom Drug Codes -->
-                    <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        @if (Model.CustomDrugCodes != null && Model.CustomDrugCodes.Count() > 0)
-                        {
-                            for (int j = defaultMedsMedian; j < Model.CustomDrugCodes.Count; j++)
-                            {
-                                var drugCode = Model.CustomDrugCodes[j];
-                                var displayName = drugCode.DrugName;
-
-                                if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
-                                {
-                                    displayName += " (" + drugCode.BrandName + ")";
-                                }
-                                <div>
-                                    <fieldset>
-                                        <div class="space-y-5">
-                                            <div class="relative flex items-start">
-                                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                                <div class="flex h-6 items-center">
-                                                    <input asp-for="CustomDrugCodes[j].Id" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[j].RxNormId" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[j].DrugName" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[j].BrandName" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[j].IsOverTheCounter" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[j].IsPopular" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[j].IsSelected" type="checkbox" class="@checkboxCSS" />
-                                                </div>
-                                                <div class="ml-3 text-sm leading-6">
-                                                    <label for="@Html.IdFor(m => m.CustomDrugCodes[j].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.CustomDrugCodes[j].RxNormId</span></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                            }
-                        }
-                    </div>
+                <div>
+                    <a asp-page="/RxNorm/Search" asp-route-id="@Model.Visit.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Add</a>
                 </div>
             </div>
         </div>
+
+        <!-- Custom Drug Codes -->
+        <div class="grid lg:grid-cols-2 sm:grid-cols-2">
+            <!-- Left  Column Custom Drug Codes -->
+            <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                @if (Model.CustomDrugCodes != null && Model.CustomDrugCodes.Count() > 0)
+                {
+                    for (int i = 0; i < defaultMedsMedianCustom; i++)
+                    {
+                        var drugCode = Model.CustomDrugCodes[i];
+                        var displayName = drugCode.DrugName;
+
+                        if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
+                        {
+                            displayName += " (" + drugCode.BrandName + ")";
+                        }
+                        <div>
+                            <fieldset>
+                                <div class="space-y-5">
+                                    <div class="relative flex items-start">
+                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                        <div class="flex h-6 items-center">
+                                            <input asp-for="CustomDrugCodes[i].Id" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].RxNormId" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].DrugName" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].BrandName" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].IsOverTheCounter" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].IsPopular" type="hidden" />
+                                            <input asp-for="@Model.CustomDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" />
+                                        </div>
+                                        <div class="ml-3 text-sm leading-6">
+                                            <label for="@Html.IdFor(m => m.CustomDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.CustomDrugCodes[i].RxNormId</span></label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                    }
+                }
+            </div>
+
+            <!-- Right  Column Custom Drug Codes -->
+            <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                @if (Model.CustomDrugCodes != null && Model.CustomDrugCodes.Count() > 0)
+                {
+                    for (int j = defaultMedsMedian; j < Model.CustomDrugCodes.Count; j++)
+                    {
+                        var drugCode = Model.CustomDrugCodes[j];
+                        var displayName = drugCode.DrugName;
+
+                        if (!string.IsNullOrWhiteSpace(drugCode.BrandName))
+                        {
+                            displayName += " (" + drugCode.BrandName + ")";
+                        }
+                        <div>
+                            <fieldset>
+                                <div class="space-y-5">
+                                    <div class="relative flex items-start">
+                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                        <div class="flex h-6 items-center">
+                                            <input asp-for="CustomDrugCodes[j].Id" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[j].RxNormId" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[j].DrugName" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[j].BrandName" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[j].IsOverTheCounter" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[j].IsPopular" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[j].IsSelected" type="checkbox" class="@checkboxCSS" />
+                                        </div>
+                                        <div class="ml-3 text-sm leading-6">
+                                            <label for="@Html.IdFor(m => m.CustomDrugCodes[j].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.CustomDrugCodes[j].RxNormId</span></label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+
+    </div>
 </div>
+
 
 <partial name="_FormFooter" for="@Model.A4" />
 

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -6,139 +6,140 @@
     string checkboxCSS = "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none";
 }
 
+
+<p class="mt-1 text-sm text-gray-500">
+    INSTRUCTIONS: This form is to be completed by the clinician or ADRC staff. The purpose of this form is to record all prescription medications taken by the participant within the <strong>two weeks before the current visit.</strong> If the participant is receiving any treatments known to significantly impact Alzheimer disease and related dementias (ADRD) biomarkers as part of their clinical care at the time of clinical assessment (e.g., they are receiving aducanumab infusions), the treatment should be included on both this form and the A4a ADRD–Specific Treatments form. For prescription medications not listed here, please follow the instructions at the end of this form. OTC (non-prescription) medications need not be reported; however, a short list of medications that could be either prescription or OTC follows the prescription list. For additional clarification and examples, see <guidebook kind="@Model.Visit.PACKET"></guidebook> for <strong>Form A4.</strong>
+</p>
 <div>
-    <p class="mt-1 text-sm text-gray-500">
-        INSTRUCTIONS: This form is to be completed by the clinician or ADRC staff. The purpose of this form is to record all prescription medications taken by the participant within the <strong>two weeks before the current visit.</strong> If the participant is receiving any treatments known to significantly impact Alzheimer disease and related dementias (ADRD) biomarkers as part of their clinical care at the time of clinical assessment (e.g., they are receiving aducanumab infusions), the treatment should be included on both this form and the A4a ADRD–Specific Treatments form. For prescription medications not listed here, please follow the instructions at the end of this form. OTC (non-prescription) medications need not be reported; however, a short list of medications that could be either prescription or OTC follows the prescription list. For additional clarification and examples, see <guidebook kind="@Model.Visit.PACKET"></guidebook> for <strong>Form A4.</strong>
-        <div>
-            <div class="mt-10 space-y-8 border-b border-gray-900/10 pb-12 sm:space-y-0 sm:divide-y sm:divide-gray-900/10 sm:border-t sm:pb-0">
+    <div class="mt-10 space-y-8 border-b border-gray-900/10 pb-12 sm:space-y-0 sm:divide-y sm:divide-gray-900/10 sm:border-t sm:pb-0">
 
-                <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A4.ANYMEDS"><span class="counter"></span> @Html.DisplayNameFor(m => m.A4.ANYMEDS)</label>
-                    <div class="mt-4 sm:col-span-2 sm:mt-0">
-                        <p class="text-sm text-gray-500" asp-description-for="@Model.A4.ANYMEDS"></p>
-                        <radio-button-group id="@Html.IdFor(m => m.A4.ANYMEDS)" for="@Model.A4.ANYMEDS" items="Model.MedicationsWithinLastTwoWeeksListItems"></radio-button-group>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="A4.ANYMEDS"></span>
-                    </div>
-                </div>
-
-                <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
-                    @if (Model.PopularDrugCodes != null || Model.PopularDrugCodes.Count() == 0)
-                    {
-                        for (int i = 0; i < Model.PopularDrugCodes.Count(); i++)
-                        {
-                            var displayName = Model.PopularDrugCodes[i].DrugName;
-                            if (!string.IsNullOrWhiteSpace(Model.PopularDrugCodes[i].BrandName))
-                            {
-                                displayName += " (" + Model.PopularDrugCodes[i].BrandName + ")";
-                            }
-                            <fieldset>
-                                <div class="space-y-5">
-                                    <div class="relative flex items-start">
-                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                        <div class="flex h-6 items-center">
-                                            <input asp-for="PopularDrugCodes[i].Id" type="hidden" />
-                                            <input asp-for="PopularDrugCodes[i].RxNormId " type="hidden" />
-                                            <input asp-for="PopularDrugCodes[i].DrugName" type="hidden" />
-                                            <input asp-for="PopularDrugCodes[i].BrandName" type="hidden" />
-                                            <input asp-for="PopularDrugCodes[i].IsOverTheCounter" type="hidden" />
-                                            <input asp-for="PopularDrugCodes[i].IsPopular" type="hidden" />
-                                            <input asp-for="PopularDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" disabled />
-                                        </div>
-                                        <div class="ml-3 text-sm leading-6">
-                                            <label for="@Html.IdFor(m => m.PopularDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.PopularDrugCodes[i].RxNormId</span></label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </fieldset>
-                        }
-                    }
-                    else
-                    {
-                        <p class="sm:gap-4 sm:py-">No drug codes found in the reference. Ask your IT to insert drug codes from NACC reference.</p>
-                    }
-                </div>
-
-                @if (Model.OTCDrugCodes != null || Model.OTCDrugCodes.Count() == 0)
-                {
-                    <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                        <p>Commonly reported medications that may be purchased over the counter (but that may also be prescription)</p>
-                    </div>
-                    <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
-                        @for (int i = 0; i < Model.OTCDrugCodes.Count(); i++)
-                        {
-                            var displayName = Model.OTCDrugCodes[i].DrugName;
-                            if (!string.IsNullOrWhiteSpace(Model.OTCDrugCodes[i].BrandName))
-                            {
-                                displayName += " (" + Model.OTCDrugCodes[i].BrandName + ")";
-                            }
-                            <fieldset>
-                                <div class="space-y-5">
-                                    <div class="relative flex items-start">
-                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                        <div class="flex h-6 items-center">
-                                            <input asp-for="OTCDrugCodes[i].Id" type="hidden" />
-                                            <input asp-for="OTCDrugCodes[i].RxNormId" type="hidden" />
-                                            <input asp-for="OTCDrugCodes[i].DrugName" type="hidden" />
-                                            <input asp-for="OTCDrugCodes[i].BrandName" type="hidden" />
-                                            <input asp-for="OTCDrugCodes[i].IsOverTheCounter" type="hidden" />
-                                            <input asp-for="OTCDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" disabled />
-                                        </div>
-                                        <div class="ml-3 text-sm leading-6">
-                                            <label for="@Html.IdFor(m => m.OTCDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.OTCDrugCodes[i].RxNormId</span></label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </fieldset>
-                        }
-                    </div>
-                }
-                else
-                {
-                    <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
-                        <p class="">No drug codes found in the reference. Ask your IT to insert drug codes from NACC reference.</p>
-                    </div>
-                }
-
-
-                <div class="sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
-                    <div>
-                        @if (Model.CustomDrugCodes != null || Model.CustomDrugCodes.Count() == 0)
-                        {
-                            <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
-                                @for (int i = 0; i < Model.CustomDrugCodes.Count(); i++)
-                                {
-                                    var displayName = Model.CustomDrugCodes[i].DrugName;
-                                    if (!string.IsNullOrWhiteSpace(Model.CustomDrugCodes[i].BrandName))
-                                    {
-                                        displayName += " (" + Model.CustomDrugCodes[i].BrandName + ")";
-                                    }
-                                    <fieldset>
-                                        <div class="space-y-5">
-                                            <div class="relative flex items-start">
-                                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
-                                                <div class="flex h-6 items-center">
-                                                    <input asp-for="CustomDrugCodes[i].Id" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].RxNormId" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].DrugName" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].BrandName" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].IsOverTheCounter" type="hidden" />
-                                                    <input asp-for="CustomDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" disabled />
-                                                </div>
-                                                <div class="ml-3 text-sm leading-6">
-                                                    <label for="@Html.IdFor(m => m.CustomDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.CustomDrugCodes[i].RxNormId</span></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                }
-                            </div>
-                        }
-                    </div>
-                </div>
+        <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
+            <label asp-for="A4.ANYMEDS"><span class="counter"></span> @Html.DisplayNameFor(m => m.A4.ANYMEDS)</label>
+            <div class="mt-4 sm:col-span-2 sm:mt-0">
+                <p class="text-sm text-gray-500" asp-description-for="@Model.A4.ANYMEDS"></p>
+                <radio-button-group id="@Html.IdFor(m => m.A4.ANYMEDS)" for="@Model.A4.ANYMEDS" items="Model.MedicationsWithinLastTwoWeeksListItems"></radio-button-group>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="A4.ANYMEDS"></span>
             </div>
         </div>
-        <partial name="_FormFooter" for="@Model.A4" />
 
-        @section Scripts {
-            <script src="~/_content/UDS.Net.Forms/js/A4.js"></script>
+        <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
+            @if (Model.PopularDrugCodes != null || Model.PopularDrugCodes.Count() == 0)
+            {
+                for (int i = 0; i < Model.PopularDrugCodes.Count(); i++)
+                {
+                    var displayName = Model.PopularDrugCodes[i].DrugName;
+                    if (!string.IsNullOrWhiteSpace(Model.PopularDrugCodes[i].BrandName))
+                    {
+                        displayName += " (" + Model.PopularDrugCodes[i].BrandName + ")";
+                    }
+                    <fieldset>
+                        <div class="space-y-5">
+                            <div class="relative flex items-start">
+                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                <div class="flex h-6 items-center">
+                                    <input asp-for="PopularDrugCodes[i].Id" type="hidden" />
+                                    <input asp-for="PopularDrugCodes[i].RxNormId " type="hidden" />
+                                    <input asp-for="PopularDrugCodes[i].DrugName" type="hidden" />
+                                    <input asp-for="PopularDrugCodes[i].BrandName" type="hidden" />
+                                    <input asp-for="PopularDrugCodes[i].IsOverTheCounter" type="hidden" />
+                                    <input asp-for="PopularDrugCodes[i].IsPopular" type="hidden" />
+                                    <input asp-for="PopularDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" disabled />
+                                </div>
+                                <div class="ml-3 text-sm leading-6">
+                                    <label for="@Html.IdFor(m => m.PopularDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.PopularDrugCodes[i].RxNormId</span></label>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                }
+            }
+            else
+            {
+                <p class="sm:gap-4 sm:py-">No drug codes found in the reference. Ask your IT to insert drug codes from NACC reference.</p>
+            }
+        </div>
+
+        @if (Model.OTCDrugCodes != null || Model.OTCDrugCodes.Count() == 0)
+        {
+            <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                <p>Commonly reported medications that may be purchased over the counter (but that may also be prescription)</p>
+            </div>
+            <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
+                @for (int i = 0; i < Model.OTCDrugCodes.Count(); i++)
+                {
+                    var displayName = Model.OTCDrugCodes[i].DrugName;
+                    if (!string.IsNullOrWhiteSpace(Model.OTCDrugCodes[i].BrandName))
+                    {
+                        displayName += " (" + Model.OTCDrugCodes[i].BrandName + ")";
+                    }
+                    <fieldset>
+                        <div class="space-y-5">
+                            <div class="relative flex items-start">
+                                <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                <div class="flex h-6 items-center">
+                                    <input asp-for="OTCDrugCodes[i].Id" type="hidden" />
+                                    <input asp-for="OTCDrugCodes[i].RxNormId" type="hidden" />
+                                    <input asp-for="OTCDrugCodes[i].DrugName" type="hidden" />
+                                    <input asp-for="OTCDrugCodes[i].BrandName" type="hidden" />
+                                    <input asp-for="OTCDrugCodes[i].IsOverTheCounter" type="hidden" />
+                                    <input asp-for="OTCDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" disabled />
+                                </div>
+                                <div class="ml-3 text-sm leading-6">
+                                    <label for="@Html.IdFor(m => m.OTCDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.OTCDrugCodes[i].RxNormId</span></label>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                }
+            </div>
         }
+        else
+        {
+            <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
+                <p class="">No drug codes found in the reference. Ask your IT to insert drug codes from NACC reference.</p>
+            </div>
+        }
+
+
+        <div class="sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
+            <div>
+                @if (Model.CustomDrugCodes != null || Model.CustomDrugCodes.Count() == 0)
+                {
+                    <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+                        @for (int i = 0; i < Model.CustomDrugCodes.Count(); i++)
+                        {
+                            var displayName = Model.CustomDrugCodes[i].DrugName;
+                            if (!string.IsNullOrWhiteSpace(Model.CustomDrugCodes[i].BrandName))
+                            {
+                                displayName += " (" + Model.CustomDrugCodes[i].BrandName + ")";
+                            }
+                            <fieldset>
+                                <div class="space-y-5">
+                                    <div class="relative flex items-start">
+                                        <span class="mr-3 block text-sm font-medium leading-6 text-gray-900"></span>
+                                        <div class="flex h-6 items-center">
+                                            <input asp-for="CustomDrugCodes[i].Id" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].RxNormId" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].DrugName" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].BrandName" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].IsOverTheCounter" type="hidden" />
+                                            <input asp-for="CustomDrugCodes[i].IsSelected" type="checkbox" class="@checkboxCSS" disabled />
+                                        </div>
+                                        <div class="ml-3 text-sm leading-6">
+                                            <label for="@Html.IdFor(m => m.CustomDrugCodes[i].IsSelected)" class="font-medium text-gray-900">@displayName <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">@Model.CustomDrugCodes[i].RxNormId</span></label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+<partial name="_FormFooter" for="@Model.A4" />
+
+@section Scripts {
+    <script src="~/_content/UDS.Net.Forms/js/A4.js"></script>
+}

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -9,7 +9,6 @@
     int defaultMedsMedianCustom = (int)Math.Ceiling((double)Model.CustomDrugCodes.Count / 2);
 }
 
-
 <p class="mt-1 text-sm text-gray-500">
     INSTRUCTIONS: This form is to be completed by the clinician or ADRC staff. The purpose of this form is to record all prescription medications taken by the participant within the <strong>two weeks before the current visit.</strong> If the participant is receiving any treatments known to significantly impact Alzheimer disease and related dementias (ADRD) biomarkers as part of their clinical care at the time of clinical assessment (e.g., they are receiving aducanumab infusions), the treatment should be included on both this form and the A4a ADRD–Specific Treatments form. For prescription medications not listed here, please follow the instructions at the end of this form. OTC (non-prescription) medications need not be reported; however, a short list of medications that could be either prescription or OTC follows the prescription list. For additional clarification and examples, see <guidebook kind="@Model.Visit.PACKET"></guidebook> for <strong>Form A4.</strong>
 </p>
@@ -249,7 +248,7 @@
             <div class="flex flex-col sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
                 @if (Model.CustomDrugCodes != null && Model.CustomDrugCodes.Count() > 0)
                 {
-                    for (int j = defaultMedsMedian; j < Model.CustomDrugCodes.Count; j++)
+                    for (int j = defaultMedsMedianCustom; j < Model.CustomDrugCodes.Count; j++)
                     {
                         var drugCode = Model.CustomDrugCodes[j];
                         var displayName = drugCode.DrugName;

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -106,7 +106,7 @@
                 <p>Use the "Add" button to search for a valid RXNorm code by drug or brand name.</p>
             </div>
             <div>
-                <a asp-page="/RxNorm/Search">Add</a>
+                <a asp-page="/RxNorm/Search" asp-route-id="@Model.Visit.Id">Add</a>
             </div>
         </div>
         <div class="sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -199,7 +199,7 @@
                     <p>Use the "Add" button to search for a valid RXNorm code by drug or brand name.</p>
                 </div>
                 <div>
-                    <a asp-page="/RxNorm/Search" asp-route-id="@Model.Visit.Id" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Add</a>
+                    <input type="submit" name="addCustomMed" value="Add" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" />
                 </div>
             </div>
         </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml
@@ -100,15 +100,7 @@
             </div>
         }
 
-        <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
-            <div>
-                <p><strong>If a medication is not listed above</strong></p>
-                <p>Use the "Add" button to search for a valid RXNorm code by drug or brand name.</p>
-            </div>
-            <div>
-                <a asp-page="/RxNorm/Search" asp-route-id="@Model.Visit.Id">Add</a>
-            </div>
-        </div>
+        <!--// Custom medications //-->
         <div class="sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
             <div>
                 @if (Model.CustomDrugCodes != null || Model.CustomDrugCodes.Count() == 0)
@@ -142,6 +134,15 @@
                         }
                     </div>
                 }
+            </div>
+        </div>
+        <div class="flex flex-col sm:grid sm:grid-cols-2 sm:items-start sm:gap-4 sm:py-6">
+            <div>
+                <p><strong>If a medication is not listed above</strong></p>
+                <p>Use the "Add" button to search for a valid RXNorm code by drug or brand name.</p>
+            </div>
+            <div>
+                <a asp-page="/RxNorm/Search" asp-route-id="@Model.Visit.Id">Add</a>
             </div>
         </div>
     </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
@@ -137,7 +137,7 @@ namespace UDS.Net.Forms.Pages.UDS4
         }
 
         [ValidateAntiForgeryToken]
-        public new async Task<IActionResult> OnPostAsync(int id)
+        public new async Task<IActionResult> OnPostAsync(int id, string? addCustomMed)
         {
             // Reassemble the model's A4D state based on the bound properties
             foreach (var p in PopularDrugCodes)
@@ -158,7 +158,15 @@ namespace UDS.Net.Forms.Pages.UDS4
 
             Visit.Forms.Add(A4); // visit needs updated form as well
 
-            return await base.OnPostAsync(id); // checks for validation, etc.
+            if (string.IsNullOrWhiteSpace(addCustomMed))
+            {
+                return await base.OnPostAsync(id); // checks for validation, etc.
+            }
+            else
+            {
+                await base.OnPostAsync(id);
+                return RedirectToPage("/RxNorm/Search", new { Id = id });
+            }
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using rxNorm.Net.Api.Wrapper;
 using UDS.Net.Forms.Extensions;
 using UDS.Net.Forms.Models;
 using UDS.Net.Forms.Models.PageModels;
@@ -17,6 +18,7 @@ namespace UDS.Net.Forms.Pages.UDS4
     public class A4Model : FormPageModel
     {
         protected readonly ILookupService _lookupService;
+        protected readonly IRxNormClient _rxNormClient;
 
         [BindProperty]
         public A4 A4 { get; set; } = default!;
@@ -37,9 +39,10 @@ namespace UDS.Net.Forms.Pages.UDS4
             new RadioListItem("Yes", "1")
         };
 
-        public A4Model(IVisitService visitService, ILookupService lookupService) : base(visitService, "A4")
+        public A4Model(IVisitService visitService, ILookupService lookupService, IRxNormClient rxNormClient) : base(visitService, "A4")
         {
             _lookupService = lookupService;
+            _rxNormClient = rxNormClient ?? throw new ArgumentNullException(nameof(rxNormClient));
         }
 
         private async Task PopulateDrugCodeLists(List<DrugCodeModel> interactedDrugIds)
@@ -110,6 +113,8 @@ namespace UDS.Net.Forms.Pages.UDS4
 
             await PopulateDrugCodeLists(A4.DrugIds); // put the model's A4D state into separate lists
 
+            var search = await _rxNormClient.SearchDisplayTermsAsync("tylenol");
+
             return Page();
         }
 
@@ -163,6 +168,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             {
                 AssessDrugId(c);
             }
+
 
             BaseForm = A4; // reassign bounded and derived form to base form for base method
 

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
@@ -139,7 +139,10 @@ namespace UDS.Net.Forms.Pages.UDS4
                             vm.IsDeleted = true; // unchecked (soft delete)
                         }
                     }
-                    A4.DrugIds.Add(vm);
+                    // We now have a scenario where custom drug ids can be manually entered, so there is potential for duplicates
+                    // across popular, OTC, and custom lists. We'll check for duplicates before adding drug to list of DrugIds.
+                    if (!A4.DrugIds.Where(d => d.RxNormId == vm.RxNormId && d.IsDeleted == false).Any())
+                        A4.DrugIds.Add(vm);
                 }
             }
         }

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using rxNorm.Net.Api.Wrapper;
 using UDS.Net.Forms.Extensions;
 using UDS.Net.Forms.Models;
 using UDS.Net.Forms.Models.PageModels;
@@ -18,7 +17,6 @@ namespace UDS.Net.Forms.Pages.UDS4
     public class A4Model : FormPageModel
     {
         protected readonly ILookupService _lookupService;
-        protected readonly IRxNormClient _rxNormClient;
 
         [BindProperty]
         public A4 A4 { get; set; } = default!;
@@ -39,10 +37,9 @@ namespace UDS.Net.Forms.Pages.UDS4
             new RadioListItem("Yes", "1")
         };
 
-        public A4Model(IVisitService visitService, ILookupService lookupService, IRxNormClient rxNormClient) : base(visitService, "A4")
+        public A4Model(IVisitService visitService, ILookupService lookupService) : base(visitService, "A4")
         {
             _lookupService = lookupService;
-            _rxNormClient = rxNormClient ?? throw new ArgumentNullException(nameof(rxNormClient));
         }
 
         private async Task PopulateDrugCodeLists(List<DrugCodeModel> interactedDrugIds)
@@ -112,8 +109,6 @@ namespace UDS.Net.Forms.Pages.UDS4
             }
 
             await PopulateDrugCodeLists(A4.DrugIds); // put the model's A4D state into separate lists
-
-            var search = await _rxNormClient.SearchDisplayTermsAsync("tylenol");
 
             return Page();
         }

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -37,6 +37,5 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.0" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -25,8 +25,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
 		<PackageReference Include="CsvHelper" Version="33.0.1" />
 		<PackageReference Include="NSwag.ApiDescription.Client" Version="14.1.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -37,5 +37,6 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.0" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.6.12</Version>
+		<Version>5.0.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>5.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>5.0.0-preview.2</Version>
+		<Version>5.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>5.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>5.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
+++ b/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
@@ -69,7 +69,6 @@
 
             <div class="divide-y divide-gray-200">
                 @if (Model.BaseForm.Kind == "C2" || Model.BaseForm.Kind == "C2T")
-
                 {
                     <form method="post" id="UDSForm">
                         <input name="Enum.FormMode.NotCompleted" value="@(((int)FormMode.NotCompleted).ToString())" type="hidden" />
@@ -88,15 +87,13 @@
                         <input asp-for="Visit.IsDeleted" type="hidden" />
 
                         <div class="counterreset space-y-12 sm:space-y-16 mt-2">
-
                             @RenderBody()
                         </div>
                     </form>
                 }
-
                 else
-
                 {
+                    <!--// Turn off turbo for all other forms //-->
                     <form method="post" id="UDSForm" data-turbo="false">
                         <input name="Enum.FormMode.NotCompleted" value="@(((int)FormMode.NotCompleted).ToString())" type="hidden" />
                         <input name="Enum.FormStatus.Finalized" value="@(((int)FormStatus.Finalized).ToString())" type="hidden" />
@@ -114,7 +111,6 @@
                         <input asp-for="Visit.IsDeleted" type="hidden" />
 
                         <div class="counterreset space-y-12 sm:space-y-16 mt-2">
-
                             @RenderBody()
                         </div>
                     </form>

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/autocomplete_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/autocomplete_controller.js
@@ -14,15 +14,23 @@ export default class extends Controller {
   }
 
   filterList(event) {
-    var startsWithMatcher = new RegExp("^" + this.searchBoxTarget.value, "i")
-    this.itemTargets.map((item) => {
-      if (startsWithMatcher.test(item.innerHTML)) {
-        item.classList.remove("hidden")
+    // we will call the rxNormDisplayNames controller (list is ~30K)
+    if (this.searchBoxTarget.value != undefined && this.searchBoxTarget.value !== "") {
+      if (this.searchBoxTarget.value.length == 1) {
+        // this will trigger an event for rxNormDisplayNames to handle and load new entries (instead of all 30K at once)
+        this.dispatch("newSearch", { detail: { content: this.searchBoxTarget.value } })
       }
-      else {
-        item.classList.add("hidden")
-      }
-    });
+
+      var startsWithMatcher = new RegExp("^" + this.searchBoxTarget.value, "i")
+      this.itemTargets.map((item) => {
+        if (startsWithMatcher.test(item.innerHTML)) {
+          item.classList.remove("hidden")
+        }
+        else {
+          item.classList.add("hidden")
+        }
+      });
+    }
     // TODO check if list is empty and if so, display the no results
   }
 

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/autocomplete_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/autocomplete_controller.js
@@ -1,0 +1,45 @@
+﻿
+// wwwroot/js/js_controllers/autocomplete_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["searchBox", "list", "item", "noResults"]
+
+  showList(event) {
+    this.listTarget.classList.remove("hidden")
+  }
+
+  hideList(event) {
+    this.listTarget.classList.add("hidden")
+  }
+
+  filterList(event) {
+    var startsWithMatcher = new RegExp("^" + this.searchBoxTarget.value, "i")
+    this.itemTargets.map((item) => {
+      if (startsWithMatcher.test(item.innerHTML)) {
+        item.classList.remove("hidden")
+      }
+      else {
+        item.classList.add("hidden")
+      }
+    });
+    // TODO check if list is empty and if so, display the no results
+  }
+
+  showNoResults(event) {
+    this.noResultsTarget.remove("hidden")
+  }
+
+  hideNoResults(event) {
+    this.noResultsTarget.add("hidden")
+  }
+
+  setSearchBox(event) {
+    this.searchBoxTarget.value = event.target.innerHTML;
+    this.hideList();
+  }
+
+  connect() {
+    this.hideList()
+  }
+}

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/rxNormDisplayNames_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/rxNormDisplayNames_controller.js
@@ -1,0 +1,43 @@
+﻿
+// wwwroot/js/js_controllers/rxNormDisplayNames_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["list"]
+
+  connect() {
+    this.fetchData()
+
+  }
+
+  async fetchData() {
+    try {
+      const response = await fetch("https://rxnav.nlm.nih.gov/REST/displaynames.json")
+      const data = await response.json()
+      console.log(data.displayTermsList)
+      // Update the target element with the received data
+      //this.resultTarget.textContent = data.message
+      data.displayTermsList.term.map((item) => {
+        const newLi = document.createElement("li")
+        newLi.textContent = item // Set the content of the new list item
+        newLi.classList.add("cursor-default")
+        newLi.classList.add("rounded-md")
+        newLi.classList.add("px-4")
+        newLi.classList.add("py-2")
+        newLi.classList.add("select-none")
+        newLi.classList.add("hover:bg-indigo-600")
+        newLi.classList.add("hover:text-white")
+        newLi.setAttribute("data-autocomplete-target", "item")
+        newLi.setAttribute("data-action", "click->autocomplete#setSearchBox")
+        newLi.id = "option"
+        newLi.role = "option"
+        newLi.tabIndex = -1
+        this.listTarget.appendChild(newLi)
+      })
+
+    } catch (error) {
+      console.error("Error fetching data:", error)
+    }
+  }
+
+}

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/rxNormDisplayNames_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/rxNormDisplayNames_controller.js
@@ -4,7 +4,9 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["list"]
-  static values = { fetchedLetters: Array }
+  static values = {
+    fetchedLetters: String
+  }
 
   initialize() {
   }
@@ -15,16 +17,14 @@ export default class extends Controller {
 
   async fetchData({ detail: { content } }) {
     var search = content;
-    console.log(this.fetchedLettersValue)
     if (!this.fetchedLettersValue.includes(search)) {
-      this.fetchedLettersValue.push(search)
-      console.log("fetching for " + search)
+      this.fetchedLettersValue = this.fetchedLettersValue + search;
+      //console.log("fetching for " + search)
       try {
         const response = await fetch("https://rxnav.nlm.nih.gov/REST/displaynames.json")
         const data = await response.json()
 
-        // Update the target element with the received data
-        //this.resultTarget.textContent = data.message
+        // Update the list with the received data
         data.displayTermsList.term.forEach(item => {
           var startsWithMatcher = new RegExp("^" + search, "i")
           if (startsWithMatcher.test(item)) {
@@ -39,7 +39,6 @@ export default class extends Controller {
             newLi.classList.add("hover:text-white")
             newLi.setAttribute("data-autocomplete-target", "item")
             newLi.setAttribute("data-action", "click->autocomplete#setSearchBox")
-            newLi.id = "option"
             newLi.role = "option"
             newLi.tabIndex = -1
             this.listTarget.appendChild(newLi)

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/rxNormDisplayNames_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/rxNormDisplayNames_controller.js
@@ -4,39 +4,51 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["list"]
+  static values = { fetchedLetters: Array }
 
-  connect() {
-    this.fetchData()
-
+  initialize() {
   }
 
-  async fetchData() {
-    try {
-      const response = await fetch("https://rxnav.nlm.nih.gov/REST/displaynames.json")
-      const data = await response.json()
-      console.log(data.displayTermsList)
-      // Update the target element with the received data
-      //this.resultTarget.textContent = data.message
-      data.displayTermsList.term.map((item) => {
-        const newLi = document.createElement("li")
-        newLi.textContent = item // Set the content of the new list item
-        newLi.classList.add("cursor-default")
-        newLi.classList.add("rounded-md")
-        newLi.classList.add("px-4")
-        newLi.classList.add("py-2")
-        newLi.classList.add("select-none")
-        newLi.classList.add("hover:bg-indigo-600")
-        newLi.classList.add("hover:text-white")
-        newLi.setAttribute("data-autocomplete-target", "item")
-        newLi.setAttribute("data-action", "click->autocomplete#setSearchBox")
-        newLi.id = "option"
-        newLi.role = "option"
-        newLi.tabIndex = -1
-        this.listTarget.appendChild(newLi)
-      })
+  connect() {
+    this.fetchData({ detail: { content: "a" } }); // initialize with "a" drugs
+  }
 
-    } catch (error) {
-      console.error("Error fetching data:", error)
+  async fetchData({ detail: { content } }) {
+    var search = content;
+    console.log(this.fetchedLettersValue)
+    if (!this.fetchedLettersValue.includes(search)) {
+      this.fetchedLettersValue.push(search)
+      console.log("fetching for " + search)
+      try {
+        const response = await fetch("https://rxnav.nlm.nih.gov/REST/displaynames.json")
+        const data = await response.json()
+
+        // Update the target element with the received data
+        //this.resultTarget.textContent = data.message
+        data.displayTermsList.term.forEach(item => {
+          var startsWithMatcher = new RegExp("^" + search, "i")
+          if (startsWithMatcher.test(item)) {
+            const newLi = document.createElement("li")
+            newLi.textContent = item // Set the content of the new list item
+            newLi.classList.add("cursor-default")
+            newLi.classList.add("rounded-md")
+            newLi.classList.add("px-4")
+            newLi.classList.add("py-2")
+            newLi.classList.add("select-none")
+            newLi.classList.add("hover:bg-indigo-600")
+            newLi.classList.add("hover:text-white")
+            newLi.setAttribute("data-autocomplete-target", "item")
+            newLi.setAttribute("data-action", "click->autocomplete#setSearchBox")
+            newLi.id = "option"
+            newLi.role = "option"
+            newLi.tabIndex = -1
+            this.listTarget.appendChild(newLi)
+          }
+        })
+
+      } catch (error) {
+        console.error("Error fetching data:", error)
+      }
     }
   }
 

--- a/src/UDS.Net.Forms/wwwroot/js/stimulus_controllers.js
+++ b/src/UDS.Net.Forms/wwwroot/js/stimulus_controllers.js
@@ -6,6 +6,8 @@ import FancyCheckboxes from "./js_controllers/fancycheckboxes_controller.js"
 import CheckboxDisable from "./js_controllers/checkboxDisable_controller.js"
 import selectendpoint_controller from "./js_controllers/selectendpoint_controller.js"
 import checkboxSelectAll from "./js_controllers/checkboxSelectAll_controller.js"
+import rxNormDisplayNames from "./js_controllers/rxNormDisplayNames_controller.js"
+import autocomplete from "./js_controllers/autocomplete_controller.js"
 
 window.Stimulus = Application.start()
 
@@ -16,3 +18,5 @@ Stimulus.register("fancycheckboxes", FancyCheckboxes)
 Stimulus.register("checkboxDisable", CheckboxDisable)
 Stimulus.register("selectendpoint", selectendpoint_controller)
 Stimulus.register("checkboxSelectAll", checkboxSelectAll)
+Stimulus.register("rxNormDisplayNames", rxNormDisplayNames)
+Stimulus.register("autocomplete", autocomplete)

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>5.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>5.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>5.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
@@ -10,6 +10,7 @@ using UDS.Net.Services.DomainModels;
 using UDS.Net.Services.DomainModels.Forms;
 using UDS.Net.Services.DomainModels.Submission;
 using UDS.Net.Services.Enums;
+using UDS.Net.Services.LookupModels;
 
 namespace UDS.Net.Services.Extensions
 {
@@ -1632,6 +1633,18 @@ namespace UDS.Net.Services.Extensions
                 OTHCOG = fields.OTHCOG,
                 OTHCOGIF = fields.OTHCOGIF,
                 OTHCOGX = fields.OTHCOGX
+            };
+        }
+
+        public static DrugCodeDto ToDto(this DrugCode drugCode)
+        {
+            return new DrugCodeDto
+            {
+                RxNormId = Int32.Parse(drugCode.RxNormId),
+                DrugName = drugCode.DrugName,
+                BrandName = drugCode.BrandName,
+                IsOverTheCounter = drugCode.IsOverTheCounter,
+                IsPopular = drugCode.IsPopular
             };
         }
     }

--- a/src/UDS.Net.Services/Extensions/DtoToDomainMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DtoToDomainMapper.cs
@@ -6,6 +6,7 @@ using UDS.Net.Services.DomainModels;
 using UDS.Net.Services.DomainModels.Forms;
 using UDS.Net.Services.DomainModels.Submission;
 using UDS.Net.Services.Enums;
+using UDS.Net.Services.LookupModels;
 
 namespace UDS.Net.Services.Extensions
 {
@@ -402,6 +403,18 @@ namespace UDS.Net.Services.Extensions
             }
 
             return new PacketSubmissionError(dto.Id, dto.PacketSubmissionId, dto.FormKind, dto.Message, dto.AssignedTo, packetSubmissionErrorLevel, dto.ResolvedBy, dto.CreatedAt, dto.CreatedBy, dto.ModifiedBy, dto.DeletedBy, dto.IsDeleted);
+        }
+
+        public static DrugCode ToDomain(this DrugCodeDto dto)
+        {
+            return new DrugCode
+            {
+                RxNormId = dto.RxNormId.ToString(),
+                DrugName = dto.DrugName,
+                BrandName = dto.BrandName,
+                IsOverTheCounter = dto.IsOverTheCounter,
+                IsPopular = dto.IsPopular
+            };
         }
     }
 }

--- a/src/UDS.Net.Services/ILookupService.cs
+++ b/src/UDS.Net.Services/ILookupService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using UDS.Net.Dto;
 using UDS.Net.Services.LookupModels;
 
@@ -12,6 +13,9 @@ namespace UDS.Net.Services
 
         Task<LookupCountryCodeDto> LookupCountryCode(string countryCode);
 
+        Task<List<string>> LookupRxNormDisplayTerms();
+
+        Task<List<RxNorm>> LookupRxNormApproximateMatches(string searchTerm, int pageSize = 20);
     }
 }
 

--- a/src/UDS.Net.Services/ILookupService.cs
+++ b/src/UDS.Net.Services/ILookupService.cs
@@ -9,13 +9,15 @@ namespace UDS.Net.Services
     {
         Task<DrugCodeLookup> LookupDrugCodes(int pageSize = 10, int pageIndex = 1);
 
-        Task<DrugCodeLookup> SearchDrugCodes(int pageSize = 10, int pageIndex = 1, bool onlyPopular = true, string? searchTerm = "");
+        Task<DrugCodeLookup> SearchDrugCodes(int pageSize = 10, int pageIndex = 1, string? searchTerm = "");
 
         Task<LookupCountryCodeDto> LookupCountryCode(string countryCode);
 
         Task<List<string>> LookupRxNormDisplayTerms();
 
         Task<List<RxNorm>> LookupRxNormApproximateMatches(string searchTerm, int pageSize = 20);
+
+        Task<DrugCode> AddDrugCodeToLookup(DrugCode newDrugCode);
     }
 }
 

--- a/src/UDS.Net.Services/ILookupService.cs
+++ b/src/UDS.Net.Services/ILookupService.cs
@@ -11,6 +11,8 @@ namespace UDS.Net.Services
 
         Task<DrugCodeLookup> SearchDrugCodes(int pageSize = 10, int pageIndex = 1, string? searchTerm = "");
 
+        Task<DrugCodeLookup> FindDrugCode(string rxCUI);
+
         Task<LookupCountryCodeDto> LookupCountryCode(string countryCode);
 
         Task<List<string>> LookupRxNormDisplayTerms();

--- a/src/UDS.Net.Services/LookupModels/RxNorm.cs
+++ b/src/UDS.Net.Services/LookupModels/RxNorm.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace UDS.Net.Services.LookupModels
+{
+    public class RxNorm
+    {
+        public string Name { get; set; }
+
+        public string RxCUI { get; set; }
+    }
+}
+

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.6.12</Version>
+		<Version>5.0.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>5.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,15 +4,15 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>5.0.0-preview.2</Version>
+		<Version>5.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>5.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>5.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Web.MVC.Services/LookupService.cs
+++ b/src/UDS.Net.Web.MVC.Services/LookupService.cs
@@ -7,16 +7,19 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using UDS.Net.Services.LookupModels;
+using rxNorm.Net.Api.Wrapper;
 
 namespace UDS.Net.Web.MVC.Services
 {
     public class LookupService : ILookupService
     {
         private readonly IApiClient _apiClient;
+        private readonly IRxNormClient _rxNormClient;
 
-        public LookupService(IApiClient apiClient)
+        public LookupService(IApiClient apiClient, IRxNormClient rxNormClient)
         {
             _apiClient = apiClient;
+            _rxNormClient = rxNormClient;
         }
 
         public async Task<DrugCodeLookup> LookupDrugCodes(int pageSize = 10, int pageIndex = 1)
@@ -74,6 +77,31 @@ namespace UDS.Net.Web.MVC.Services
             };
         }
 
+        public async Task<List<string>> LookupRxNormDisplayTerms()
+        {
+            var results = await _rxNormClient.GetDisplayTermsAsync();
+
+            if (results != null)
+                return results.ToList();
+            else
+                return new List<string>();
+        }
+
+        public async Task<List<RxNorm>> LookupRxNormApproximateMatches(string searchTerm, int pageSize = 20)
+        {
+            var matches = await _rxNormClient.GetApproximateMatches(searchTerm, false, pageSize);
+            if (matches != null)
+            {
+                return matches.Select(m => new RxNorm
+                {
+                    Name = m.Name,
+                    RxCUI = m.RxCUI
+                }).ToList();
+            }
+            else
+                return new List<RxNorm>();
+        }
+
         [Obsolete]
         public Task<DrugCodeLookup> Add(string username, DrugCodeLookup entity)
         {
@@ -115,6 +143,7 @@ namespace UDS.Net.Web.MVC.Services
         {
             throw new NotImplementedException();
         }
+
     }
 }
 

--- a/src/UDS.Net.Web.MVC.Services/LookupService.cs
+++ b/src/UDS.Net.Web.MVC.Services/LookupService.cs
@@ -3,6 +3,7 @@ using System;
 using UDS.Net.API.Client;
 using UDS.Net.Dto;
 using UDS.Net.Services;
+using UDS.Net.Services.Extensions;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,34 +32,20 @@ namespace UDS.Net.Web.MVC.Services
                 PageSize = pageSize,
                 PageIndex = pageIndex,
                 TotalResultsCount = dto.TotalResultsCount,
-                DrugCodes = dto.Results.Select(r => new DrugCode
-                {
-                    RxNormId = r.RxNormId.ToString(),
-                    DrugName = r.DrugName,
-                    BrandName = r.BrandName,
-                    IsPopular = r.IsPopular,
-                    IsOverTheCounter = r.IsOverTheCounter
-                }).ToList()
+                DrugCodes = dto.Results.Select(r => r.ToDomain()).ToList()
             };
         }
 
-        public async Task<DrugCodeLookup> SearchDrugCodes(int pageSize = 10, int pageIndex = 1, bool onlyPopular = true, string searchTerm = "")
+        public async Task<DrugCodeLookup> SearchDrugCodes(int pageSize = 10, int pageIndex = 1, string searchTerm = "")
         {
-            var dto = await _apiClient.LookupClient.SearchDrugCodes(pageSize, pageSize, onlyPopular, searchTerm);
+            var dto = await _apiClient.LookupClient.SearchDrugCodes(pageSize, pageSize, searchTerm);
 
             return new DrugCodeLookup
             {
                 PageSize = pageSize,
                 PageIndex = pageIndex,
                 TotalResultsCount = dto.TotalResultsCount,
-                DrugCodes = dto.Results.Select(r => new DrugCode
-                {
-                    RxNormId = r.RxNormId.ToString(),
-                    DrugName = r.DrugName,
-                    BrandName = r.BrandName,
-                    IsPopular = r.IsPopular,
-                    IsOverTheCounter = r.IsOverTheCounter
-                }).ToList()
+                DrugCodes = dto.Results.Select(r => r.ToDomain()).ToList()
             };
         }
 
@@ -102,6 +89,13 @@ namespace UDS.Net.Web.MVC.Services
                 return new List<RxNorm>();
         }
 
+        public async Task<DrugCode> AddDrugCodeToLookup(DrugCode newDrugCode)
+        {
+            var added = await _apiClient.LookupClient.AddDrugCode(newDrugCode.ToDto());
+
+            return added.ToDomain();
+        }
+
         [Obsolete]
         public Task<DrugCodeLookup> Add(string username, DrugCodeLookup entity)
         {
@@ -143,7 +137,6 @@ namespace UDS.Net.Web.MVC.Services
         {
             throw new NotImplementedException();
         }
-
     }
 }
 

--- a/src/UDS.Net.Web.MVC.Services/LookupService.cs
+++ b/src/UDS.Net.Web.MVC.Services/LookupService.cs
@@ -49,6 +49,48 @@ namespace UDS.Net.Web.MVC.Services
             };
         }
 
+        public async Task<DrugCodeLookup> FindDrugCode(string rxCUI)
+        {
+            if (Int32.TryParse(rxCUI, out int rxNormId))
+            {
+                var dto = await _apiClient.LookupClient.FindDrugCode(rxNormId);
+                if (dto != null)
+                {
+                    if (dto.TotalResultsCount > 0 && dto.Results != null && dto.Results.Count() > 0)
+                    {
+                        var result = dto.Results.FirstOrDefault();
+                        return new DrugCodeLookup
+                        {
+                            PageSize = 1,
+                            PageIndex = 1,
+                            TotalResultsCount = 1,
+                            DrugCodes = new List<DrugCode>()
+                            {
+                                result.ToDomain()
+                            }
+                        };
+                    }
+                }
+            }
+
+            return new DrugCodeLookup
+            {
+                PageSize = 1,
+                PageIndex = 1,
+                TotalResultsCount = 0,
+                DrugCodes = new List<DrugCode>()
+            };
+        }
+
+        public async Task<DrugCode> AddDrugCodeToLookup(DrugCode newDrugCode)
+        {
+            var dto = newDrugCode.ToDto();
+
+            var added = await _apiClient.LookupClient.AddDrugCode(dto);
+
+            return added.ToDomain();
+        }
+
         public async Task<LookupCountryCodeDto> LookupCountryCode(string countryCode)
         {
             var dto = await _apiClient.LookupClient.LookupCountryCode(countryCode);
@@ -89,12 +131,6 @@ namespace UDS.Net.Web.MVC.Services
                 return new List<RxNorm>();
         }
 
-        public async Task<DrugCode> AddDrugCodeToLookup(DrugCode newDrugCode)
-        {
-            var added = await _apiClient.LookupClient.AddDrugCode(newDrugCode.ToDto());
-
-            return added.ToDomain();
-        }
 
         [Obsolete]
         public Task<DrugCodeLookup> Add(string username, DrugCodeLookup entity)
@@ -137,6 +173,7 @@ namespace UDS.Net.Web.MVC.Services
         {
             throw new NotImplementedException();
         }
+
     }
 }
 

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,19 +4,19 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.6.12</Version>
+		<Version>5.0.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>5.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.1" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.1" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.2" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.2" />
 		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -15,9 +15,9 @@
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
-		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.1" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.1" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Services\UDS.Net.Services.csproj" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
 		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Services\UDS.Net.Services.csproj" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,19 +4,19 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>5.0.0-preview.2</Version>
+		<Version>5.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>5.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>5.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.2" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0" />
 		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/Program.cs
+++ b/src/UDS.Net.Web.MVC/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.FileProviders;
+using rxNorm.Net.Api.Wrapper;
 using System.Diagnostics;
 using UDS.Net.API.Client;
 using UDS.Net.Services;
@@ -34,6 +35,8 @@ builder.Services.AddSingleton<IVisitService, VisitService>();
 builder.Services.AddSingleton<IParticipationService, ParticipationService>();
 builder.Services.AddSingleton<ILookupService, LookupService>();
 builder.Services.AddSingleton<IPacketService, PacketService>();
+
+builder.Services.AddSingleton<IRxNormClient, RxNormClient>();
 
 ////*************************************************************************************************
 

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>5.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -20,8 +20,8 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.1" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.1" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.2" />
 		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
 		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
-		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.0" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Forms\UDS.Net.Forms.csproj">

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>5.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>5.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -20,8 +20,8 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.2" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.2" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />
 		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -22,6 +22,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
 		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Forms\UDS.Net.Forms.csproj">

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -20,9 +20,9 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.API.Client" Version="4.4.0" />
-		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />
-		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.2" />
+		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0-preview.1" />
+		<PackageReference Include="UDS.Net.Dto" Version="4.5.0-preview.1" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Forms\UDS.Net.Forms.csproj">

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -15,7 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{395296FB-4036-4FC9-A8DC-A50F96D35623}"
 EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{C22F1898-8F70-49DF-B8D2-872F2CDDE162}"
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{661AC429-95F4-4D4A-9F1C-FC88522DB728}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,10 +47,10 @@ Global
 		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C22F1898-8F70-49DF-B8D2-872F2CDDE162}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C22F1898-8F70-49DF-B8D2-872F2CDDE162}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C22F1898-8F70-49DF-B8D2-872F2CDDE162}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C22F1898-8F70-49DF-B8D2-872F2CDDE162}.Release|Any CPU.Build.0 = Release|Any CPU
+		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 4.6.12
+		version = 5.0.0-preview.1
 	EndGlobalSection
 EndGlobal

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{661AC429-95F4-4D4A-9F1C-FC88522DB728}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}"
@@ -17,16 +15,30 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
 EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{D7CBAE44-14C5-47A2-87C4-B9F7E9E9141A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7CBAE44-14C5-47A2-87C4-B9F7E9E9141A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7CBAE44-14C5-47A2-87C4-B9F7E9E9141A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7CBAE44-14C5-47A2-87C4-B9F7E9E9141A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7CBAE44-14C5-47A2-87C4-B9F7E9E9141A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99F6A944-AD72-42F0-BBB1-887449A2C8E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99F6A944-AD72-42F0-BBB1-887449A2C8E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2859D284-F0ED-47CE-9B1D-70DE32451D6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2859D284-F0ED-47CE-9B1D-70DE32451D6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B18B13C-475D-4F58-947B-A80F49CF3F7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B18B13C-475D-4F58-947B-A80F49CF3F7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{332BFB18-1431-4572-BE96-757D0221FBCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{332BFB18-1431-4572-BE96-757D0221FBCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -35,6 +47,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 5.0.0-preview.2
+		version = 5.0.0
 	EndGlobalSection
 EndGlobal

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -3,19 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{04FF91D5-180F-4F0A-9881-013A82B4CA14}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{2041B528-CED9-41BD-8BFC-7F1B811BB33D}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services", "UDS.Net.Services\UDS.Net.Services.csproj", "{BD35F74B-9134-46F3-850D-7DF05F7397E4}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms.Tests", "UDS.Net.Forms.Tests\UDS.Net.Forms.Tests.csproj", "{7A359BF3-B7F2-4962-A948-DAB0A996DA0F}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", "UDS.Net.Web.MVC.Services\UDS.Net.Web.MVC.Services.csproj", "{10B4A194-D9E4-491B-AF11-FF14F6108F5F}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{395296FB-4036-4FC9-A8DC-A50F96D35623}"
-EndProject
 Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{661AC429-95F4-4D4A-9F1C-FC88522DB728}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services", "UDS.Net.Services\UDS.Net.Services.csproj", "{2859D284-F0ED-47CE-9B1D-70DE32451D6D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms.Tests", "UDS.Net.Forms.Tests\UDS.Net.Forms.Tests.csproj", "{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", "UDS.Net.Web.MVC.Services\UDS.Net.Web.MVC.Services.csproj", "{5B18B13C-475D-4F58-947B-A80F49CF3F7C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,30 +23,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{04FF91D5-180F-4F0A-9881-013A82B4CA14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{04FF91D5-180F-4F0A-9881-013A82B4CA14}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{04FF91D5-180F-4F0A-9881-013A82B4CA14}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{04FF91D5-180F-4F0A-9881-013A82B4CA14}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2041B528-CED9-41BD-8BFC-7F1B811BB33D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2041B528-CED9-41BD-8BFC-7F1B811BB33D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2041B528-CED9-41BD-8BFC-7F1B811BB33D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2041B528-CED9-41BD-8BFC-7F1B811BB33D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BD35F74B-9134-46F3-850D-7DF05F7397E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BD35F74B-9134-46F3-850D-7DF05F7397E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BD35F74B-9134-46F3-850D-7DF05F7397E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BD35F74B-9134-46F3-850D-7DF05F7397E4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7A359BF3-B7F2-4962-A948-DAB0A996DA0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7A359BF3-B7F2-4962-A948-DAB0A996DA0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7A359BF3-B7F2-4962-A948-DAB0A996DA0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7A359BF3-B7F2-4962-A948-DAB0A996DA0F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{10B4A194-D9E4-491B-AF11-FF14F6108F5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{10B4A194-D9E4-491B-AF11-FF14F6108F5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{10B4A194-D9E4-491B-AF11-FF14F6108F5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{10B4A194-D9E4-491B-AF11-FF14F6108F5F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{395296FB-4036-4FC9-A8DC-A50F96D35623}.Release|Any CPU.Build.0 = Release|Any CPU
 		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{661AC429-95F4-4D4A-9F1C-FC88522DB728}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -59,6 +35,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 5.0.0-preview.1
+		version = 5.0.0-preview.2
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fixes #239

This feature allows end-users to search RxNorm API and add more drug codes to the local lookup (there is a foreign key requirement for A4 RxNormIds to the look up).

It additionally implements several scenarios which could be possible, but does not stretch to encompass all potentially polishes for UX. This will be iterated upon as we learn more.

It implements:

- User adding custom medications to an existing form with already selected medications. RxNormIds are not allowed to duplicate.
- User adding custom medication to an unsaved form. It includes if they skip the first question `ANYMEDS`.
- User adding custom medications in consecutive order. After successfully finding the custom medication it is added to the A4 and persisted in between redirects.
- If the user attempts to add a custom medication that already exists it will search and use the local medication first.
- Saves any changes along the way to adding custom medications.

It does not implement:
- Polish such as system feedback during slow response times (relies on user not rage clicking)

### A4 flow with custom medications

<img width="1288" alt="Screenshot 2025-01-25 at 10 23 12 AM" src="https://github.com/user-attachments/assets/cc14c78e-7ea4-4179-bb39-b74b4250b717" />

<img width="1236" alt="Screenshot 2025-01-25 at 10 23 57 AM" src="https://github.com/user-attachments/assets/2e732591-5e66-48a9-8230-36141f6efc90" />


<img width="1747" alt="Screenshot 2025-01-25 at 10 24 14 AM" src="https://github.com/user-attachments/assets/412066f4-6239-43bd-93bb-5b0bc0e9ebb5" />


<img width="1318" alt="Screenshot 2025-01-25 at 10 24 23 AM" src="https://github.com/user-attachments/assets/c07a820e-4013-411e-b6a0-923f44bf763c" />


<img width="1326" alt="Screenshot 2025-01-25 at 10 24 30 AM" src="https://github.com/user-attachments/assets/40e57ceb-a722-4fb7-a899-75024cd87f8e" />
