### PR TITLE
Adjust required attribute for sub question 4h

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.6.9</ReleaseVersion>
+		<ReleaseVersion>4.6.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
@@ -221,23 +221,23 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? HEADINJURY { get; set; }
         [Display(Name = "After a head injury, what was the longest period of time that the participant was unconscious?")]
         [RegularExpression("^([0-4]|8|9)$", ErrorMessage = "Valid range is 0-4 or 8 or 9")]
-        [RequiredIf(nameof(TOBAC100), "1", ErrorMessage = "Please specify.")]
+        [RequiredIf(nameof(HEADINJURY), "1", ErrorMessage = "Please specify.")]
         public int? HEADINJUNC { get; set; }
         [Display(Name = "After a head injury, what was the longest period that the participant was \"dazed or confused\" or unable to recall details of the injury?")]
         [RegularExpression("^([0-4]|8|9)$", ErrorMessage = "Valid range is 0-4 or 8 or 9")]
-        [RequiredIf(nameof(TOBAC100), "1", ErrorMessage = "Please specify.")]
+        [RequiredIf(nameof(HEADINJURY), "1", ErrorMessage = "Please specify.")]
         public int? HEADINJCON { get; set; }
         [Display(Name = "Total number of head injuries in which the participant felt \"dazed or confused\", unable to recall details of the injury or experienced loss of consciousness?")]
         [RegularExpression("^([0-4]|9)$", ErrorMessage = "Valid range is 0-4 or 9")]
-        [RequiredIf(nameof(TOBAC100), "1", ErrorMessage = "Please specify.")]
+        [RequiredIf(nameof(HEADINJURY), "1", ErrorMessage = "Please specify.")]
         public int? HEADINJNUM { get; set; }
         [Display(Name = "Age of first head injury that resulted in a period of feeling \"dazed or confused,\" being unable to recall details of the injury, or loss of consciousness")]
         [RegularExpression("^(\\d|[1-9]\\d|10\\d|110|999)$", ErrorMessage = "Valid range is 0-110 or 999")]
-        [RequiredIf(nameof(TOBAC100), "1", ErrorMessage = "Please specify.")]
+        [RequiredIf(nameof(HEADINJURY), "1", ErrorMessage = "Please specify.")]
         public int? FIRSTTBI { get; set; }
         [Display(Name = "Age of most recent head injury that resulted in a period of feeling \"dazed or confused,\" being unable to recall details of the injury, or loss of consciousness")]
         [RegularExpression("^(\\d|[1-9]\\d|10\\d|110|999)$", ErrorMessage = "Valid range is 0-110 or 999")]
-        [RequiredIf(nameof(TOBAC100), "1", ErrorMessage = "Please specify.")]
+        [RequiredIf(nameof(HEADINJURY), "1", ErrorMessage = "Please specify.")]
         public int? LASTTBI { get; set; }
         [Display(Name = "Diabetes")]
         [RegularExpression("^([0-2]|9)$", ErrorMessage = "Valid range is 0-2 or 9")]

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.6.9</Version>
+		<Version>4.6.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.9</ReleaseVersion>
+		<ReleaseVersion>4.6.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -7,7 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <ReleaseVersion>4.6.9</ReleaseVersion>
+    <ReleaseVersion>4.6.10</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.6.9</Version>
+		<Version>4.6.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.9</ReleaseVersion>
+		<ReleaseVersion>4.6.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.6.9</Version>
+		<Version>4.6.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.9</ReleaseVersion>
+		<ReleaseVersion>4.6.10</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.6.9</ReleaseVersion>
+		<ReleaseVersion>4.6.10</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves: #246 

## Adjust the sub question validation for section 4h (HEADINJURY) in form A5D2
Sub questions were incorrectly looking at the TOBAC100 value. Now, 4h sub questions will rely on the parent 4h question (HEADINJURY) to be 1 before requiring validation

- [x] if HEADINJURY (question 4h) is 1, then require all sub 4h sub questions to have a value
- [x] if HEADINJURY (question 4h) is 0 or 9, then 4h sub-questions are NOT required for completion

### Screenshot of intended functionality in PR
#### HEADINJURY == 1 (require input)
![image](https://github.com/user-attachments/assets/a3bec0bf-87a2-44a9-87e4-5dee352fdf8b)

#### HEADINJURY == 0 || HEADINJURY == 9 (allow null)
![image](https://github.com/user-attachments/assets/a599e40b-b2c7-4cf9-a22c-b24f8c29d2e4)
