### PR TITLE
B9 Validation

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>4.6.15</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/B9.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/B9.cs
@@ -124,7 +124,6 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? BEAGGRS { get; set; }
         [Display(Name = "If any of the psychosis and impulse control–related behavioral changes in 12h–12k are present, at what age did they begin? (The clinician must use their best judgment to estimate an age of onset. If multiple symptoms are identified, denote the age of the earliest symptom.)")]
         [RegularExpression("^(9|[1-9]\\d|10\\d|110)$", ErrorMessage = "Valid range is 9 - 110")]
-        [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
         public int? PSYCHAGE { get; set; }
         [Display(Name = "Participant currently manifests meaningful change in behavior — Disinhibition")]
         [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
@@ -271,6 +270,33 @@ namespace UDS.Net.Forms.Models.UDS4
                     }
 
                     return true;
+                }
+            }
+        }
+
+        [NotMapped]
+        [RequiredOnFinalized(ErrorMessage = "Required if any respsone for questions 12h–12k are present. Must be blank when no psychosis is present")]
+        public bool? PSYCHAGESymptomsPresent
+        {
+            get
+            {
+                if (BEVHALL == 1 || BEVPATT == 1 || BEVWELL == 1 || BEAHALL == 1 || BEAHSIMP == 1 || BEAHCOMP == 1 || BEDEL == 1 || BEAGGRS == 1)
+                {
+                    if (PSYCHAGE > 0)
+                    {
+                        return true;
+                    }
+
+                    return null;
+                }
+                else
+                {
+                    if (PSYCHAGE == null)
+                    {
+                        return true;
+                    }
+
+                    return null;
                 }
             }
         }

--- a/src/UDS.Net.Forms/Models/UDS4/B9.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/B9.cs
@@ -122,7 +122,8 @@ namespace UDS.Net.Forms.Models.UDS4
         [Display(Name = "Participant currently manifests meaningful change in behavior — Aggression")]
         [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
         public int? BEAGGRS { get; set; }
-        [Display(Name = "If any of the psychosis and impulse control-related behavioral symptoms in 12h-12k are present, at what age did they begin?")]
+        [Display(Name = "If any of the psychosis and impulse control–related behavioral changes in 12h–12k are present, at what age did they begin? (The clinician must use their best judgment to estimate an age of onset. If multiple symptoms are identified, denote the age of the earliest symptom.)")]
+        [RegularExpression("^(9|[1-9]\\d|10\\d|110)$", ErrorMessage = "Valid range is 9 - 110")]
         [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
         public int? PSYCHAGE { get; set; }
         [Display(Name = "Participant currently manifests meaningful change in behavior — Disinhibition")]

--- a/src/UDS.Net.Forms/Models/UDS4/B9.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/B9.cs
@@ -172,10 +172,10 @@ namespace UDS.Net.Forms.Models.UDS4
         [Display(Name = "Was REM sleep behavior disorder confirmed by polysomnography?")]
         [RequiredIf(nameof(BEREM), "1", ErrorMessage = "Value Required")]
         public int? BEREMCONF { get; set; }
-        [Display(Name = "Other behavioral symptom")]
+        [Display(Name = "Other behavioral changes")]
         [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
         public int? BEOTHR { get; set; }
-        [Display(Name = "Participant currently manifests meaningful change in behavior - Other, specify")]
+        [Display(Name = "Other behavior changes (SPECIFY)")]
         [RequiredIf(nameof(BEOTHR), "1", ErrorMessage = "Value required")]
         [MaxLength(60)]
         public string? BEOTHRX { get; set; }

--- a/src/UDS.Net.Forms/Models/UDS4/B9.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/B9.cs
@@ -214,23 +214,23 @@ namespace UDS.Net.Forms.Models.UDS4
         [RegularExpression("^(9|[1-9]\\d|10\\d|110)$", ErrorMessage = "Valid range is 9 - 110")]
         public int? MOTORAGE { get; set; }
         [Display(Name = "Indicate the mode of onset for the most prominent motor problem that is causing the participant's complaints and/or affecting the participant's function.")]
-        [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
+        [RequiredIf(nameof(DECCLMOT), "1", ErrorMessage = "Value required")]
         public int? MOMODE { get; set; }
         [Display(Name = "Indicate mode of onset for the most prominent motor problem that is causing the participant's complains and or affecting the participant's function - Other, specify")]
         [RequiredIf(nameof(MOMODE), "4", ErrorMessage = "Value required")]
         [MaxLength(60)]
         public string? MOMODEX { get; set; }
         [Display(Name = "Were changes in motor function suggestive of parkinsonism?")]
-        [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
+        [RequiredIf(nameof(DECCLMOT), "1", ErrorMessage = "Value required")]
         public int? MOMOPARK { get; set; }
         [Display(Name = "Were changes in motor function suggestive of amyotrophic lateral sclerosis?")]
-        [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
+        [RequiredIf(nameof(DECCLMOT), "1", ErrorMessage = "Value required")]
         public int? MOMOALS { get; set; }
         [Display(Name = "Overall course of decline of cognitive / behavioral / motor syndrome")]
-        [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
+        [RequiredIf(nameof(DECCLIN), "1", ErrorMessage = "Value required")]
         public int? COURSE { get; set; }
         [Display(Name = "Indicate the predominant domain that was first recognized as changed in the participant")]
-        [RequiredIf(nameof(DECCLBE), "1", ErrorMessage = "Value required")]
+        [RequiredIf(nameof(DECCLIN), "1", ErrorMessage = "Value required")]
         public int? FRSTCHG { get; set; }
         [NotMapped]
         [RequiredIf(nameof(BESUBAB), "1", ErrorMessage = "Please select at least one substance")]

--- a/src/UDS.Net.Forms/Models/UDS4/B9.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/B9.cs
@@ -275,7 +275,7 @@ namespace UDS.Net.Forms.Models.UDS4
         }
 
         [NotMapped]
-        [RequiredOnFinalized(ErrorMessage = "Required if any respsone for questions 12h–12k are present. Must be blank when no psychosis is present")]
+        [RequiredOnFinalized(ErrorMessage = "Required if any response for questions 12h–12k are present. Must be blank when no psychosis is present.")]
         public bool? PSYCHAGESymptomsPresent
         {
             get
@@ -302,12 +302,13 @@ namespace UDS.Net.Forms.Models.UDS4
         }
 
         [NotMapped]
-        [RequiredOnFinalized(ErrorMessage = "Invalid Response")]
+        [RequiredOnFinalized(ErrorMessage = "Required if any personality-related behavioral symptoms in 12m-12r are present. Must be blank when no psychosis is present.")]
         public bool? PERCHAGESymptomsPresent
         {
             get
             {
-                if (BEVHALL == 1 || BEAHALL == 1 || BEDEL == 1 || BEAGGRS == 1 || PSYCHAGE == 1 || BEDISIN == 1 || BEPERCH == 1 || BEEMPATH == 1 || BEOBCOM == 1 || BEANGER == 1 || BESUBAB == 1)
+                // if any 12m-12r = 1
+                if (BEDISIN == 1 || BEPERCH == 1 || BEEMPATH == 1 || BEOBCOM == 1 || BEANGER == 1 || BESUBAB == 1)
                 {
                     if (PERCHAGE > 0)
                     {

--- a/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
@@ -444,7 +444,7 @@
                     </td>
                     <td colspan="2">
                         <div>
-                            <input asp-for="B9.PSYCHAGE" value="" />
+                            <input asp-for="B9.PSYCHAGE" />
                         </div>
                     </td>
                 </tr>
@@ -686,8 +686,7 @@
     </div>
     <div>
         <p class="mt-2">
-            Consider if the participant currently has meaningful change in motor function <span class="underline font-bold">that represents a change
-            relative to a stable baseline prior to the current syndrome and is potentially due to a disorder affecting the central nervous system:</span>
+            Consider if the participant currently has meaningful change in motor function <span class="underline font-bold">that represents a change relative to a stable baseline prior to the current syndrome and is potentially due to a disorder affecting the central nervous system:</span>
         </p>
     </div>
 </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
@@ -441,7 +441,11 @@
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="B9.PSYCHAGE"></span>
                         </div>
                     </td>
-                    <table-cell-radio-buttons id="B9.PSYCHAGE" for="@Model.B9.PSYCHAGE" items="Model.BasicYesNoListItems"></table-cell-radio-buttons>
+                    <td colspan="2">
+                        <div>
+                            <input asp-for="B9.PSYCHAGE" />
+                        </div>
+                    </td>
                 </tr>
                 <tr>
                     <td colspan="2">
@@ -571,7 +575,7 @@
                 <tr>
                     <td colspan="5">
                         <div class="grid grid-cols-3">
-                        <div>
+                            <div>
                                 <label asp-for="B9.PERCHAGE"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.B9.PERCHAGE)</label>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="B9.PERCHAGE"></span>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="B9.PERCHAGESymptomsPresent"></span>

--- a/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
@@ -439,11 +439,12 @@
                         <div>
                             <label asp-for="B9.PSYCHAGE"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.B9.PSYCHAGE)</label>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="B9.PSYCHAGE"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="B9.PSYCHAGESymptomsPresent"></span>
                         </div>
                     </td>
                     <td colspan="2">
                         <div>
-                            <input asp-for="B9.PSYCHAGE" />
+                            <input asp-for="B9.PSYCHAGE" value="" />
                         </div>
                     </td>
                 </tr>

--- a/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml
@@ -644,7 +644,7 @@
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="B9.BEOTHR"></span>
                     </div>
                 </td>
-                <table-cell-radio-buttons id="B9.BEOTHR" for="@Model.B9.BEOTHR" items="Model.BasicYesNoListItems" ui-behaviors="Model.BEOTHRUIBehavior"></table-cell-radio-buttons>
+                <table-cell-radio-buttons id="B9.BEOTHR" for="@Model.B9.BEOTHR" items="Model.BasicYesNoOtherListItems" ui-behaviors="Model.BEOTHRUIBehavior"></table-cell-radio-buttons>
             </tr>
             <tr class="subsubcounterreset">
                 <td colspan="5">

--- a/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml.cs
@@ -99,7 +99,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             new RadioListItem("Static", "3"),
             new RadioListItem("Fluctuating", "4"),
             new RadioListItem("Improved", "5"),
-            new RadioListItem("Not applicable", "6"),
+            new RadioListItem("Not applicable", "8"),
             new RadioListItem("Unknown", "9"),
         };
 

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>4.6.12</Version>
+		<Version>4.6.15</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>4.6.15</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>4.6.15</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>4.6.12</Version>
+		<Version>4.6.15</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>4.6.15</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.4.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -10,7 +10,7 @@
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>4.6.15</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>4.6.14</Version>
+		<Version>4.6.15</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>4.6.12</ReleaseVersion>
+		<ReleaseVersion>4.6.15</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Fixes #252
Fixes #255
Fixes #256

Corrected the properties "MOMODE,"MOMOPARK" and "MOMOALS" to be required if "DECCLMOT" has a value of 1. "COURSE" and "FRSTCHG" have also been updated to be required one "DECCLIN" has a value of 1 per documentation here --> https://github.com/naccdata/uniform-data-set/blob/main/forms/uds/b9/form_b9_ivp_error_checks_mc.csv