### PR TITLE
Add 88/8888 and 99/9999 validation to a4a date inputs

### DIFF
--- a/src/UDS.Net.Forms/Models/UDS4/A4a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A4a.cs
@@ -1,11 +1,6 @@
-﻿
-using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Xml.Linq;
-using Microsoft.Extensions.DependencyModel;
 using UDS.Net.Forms.DataAnnotations;
-using UDS.Net.Forms.TagHelpers;
 using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.Models.UDS4
@@ -152,12 +147,12 @@ namespace UDS.Net.Forms.Models.UDS4
                         }
                     }
 
-                    if (treatment.STARTYEAR.HasValue && (treatment.STARTYEAR < 1990 || treatment.STARTYEAR > DateTime.Now.Year))
+                    if (treatment.STARTYEAR.HasValue && (treatment.STARTYEAR < 1990 || treatment.STARTYEAR > DateTime.Now.Year) && (treatment.STARTYEAR.Value != 9999) && (treatment.STARTYEAR.Value != 8888))
                     {
                         yield return new ValidationResult($"Start year must be between 1990 and {DateTime.Now.Year}.", new[] { $"{treatmentIdentifier}.{nameof(treatment.STARTYEAR)}" });
                     }
 
-                    if (treatment.ENDYEAR.HasValue && (treatment.ENDYEAR < 1990 || treatment.ENDYEAR > DateTime.Now.Year))
+                    if (treatment.ENDYEAR.HasValue && (treatment.ENDYEAR < 1990 || treatment.ENDYEAR > DateTime.Now.Year) && (treatment.ENDYEAR.Value != 9999) && (treatment.ENDYEAR.Value != 8888))
                     {
                         yield return new ValidationResult($"End year must be between 1990 and {DateTime.Now.Year}.", new[] { $"{treatmentIdentifier}.{nameof(treatment.ENDYEAR)}" });
                     }

--- a/src/UDS.Net.Forms/Models/UDS4/A4a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A4a.cs
@@ -147,14 +147,14 @@ namespace UDS.Net.Forms.Models.UDS4
                         }
                     }
 
-                    if (treatment.STARTYEAR.HasValue && (treatment.STARTYEAR < 1990 || treatment.STARTYEAR > DateTime.Now.Year) && (treatment.STARTYEAR.Value != 9999) && (treatment.STARTYEAR.Value != 8888))
+                    if (treatment.STARTYEAR.HasValue && (treatment.STARTYEAR < 1990 || treatment.STARTYEAR > DateTime.Now.Year))
                     {
                         yield return new ValidationResult($"Start year must be between 1990 and {DateTime.Now.Year}.", new[] { $"{treatmentIdentifier}.{nameof(treatment.STARTYEAR)}" });
                     }
 
                     if (treatment.ENDYEAR.HasValue && (treatment.ENDYEAR < 1990 || treatment.ENDYEAR > DateTime.Now.Year) && (treatment.ENDYEAR.Value != 9999) && (treatment.ENDYEAR.Value != 8888))
                     {
-                        yield return new ValidationResult($"End year must be between 1990 and {DateTime.Now.Year}.", new[] { $"{treatmentIdentifier}.{nameof(treatment.ENDYEAR)}" });
+                        yield return new ValidationResult($"End year must be between 1990 and {DateTime.Now.Year} or 8888 or 9999", new[] { $"{treatmentIdentifier}.{nameof(treatment.ENDYEAR)}" });
                     }
 
                     index++;

--- a/src/UDS.Net.Forms/Models/UDS4/A4aTreatment.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A4aTreatment.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Xml.Linq;
+﻿using System.ComponentModel.DataAnnotations;
 using UDS.Net.Forms.DataAnnotations;
 using UDS.Net.Forms.TagHelpers;
-using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.Models.UDS4
 {
@@ -40,13 +36,14 @@ namespace UDS.Net.Forms.Models.UDS4
         [ProhibitedCharacters]
         public string? NCTNUM { get; set; }
 
-        [Range(1, 12)]
+        [RegularExpression("^([1-9]|1[0-2]|88|99)$", ErrorMessage = "Valid range is 0-36 or 88 or 99")]
         public int? STARTMO { get; set; }
 
         public int? STARTYEAR { get; set; }
 
-        [Range(1, 12)]
+        [RegularExpression("^([1-9]|1[0-2]|88|99)$", ErrorMessage = "Valid range is 0-36 or 88 or 99")]
         public int? ENDMO { get; set; }
+
 
         public int? ENDYEAR { get; set; }
 

--- a/src/UDS.Net.Forms/Models/UDS4/A4aTreatment.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A4aTreatment.cs
@@ -41,7 +41,7 @@ namespace UDS.Net.Forms.Models.UDS4
 
         public int? STARTYEAR { get; set; }
 
-        [RegularExpression("^([1-9]|1[0-2]|88|99)$", ErrorMessage = "Valid range is 0-36 or 88 or 99")]
+        [RegularExpression("^([1-9]|1[0-2]|88|99)$", ErrorMessage = "Valid range is 1 - 12 or 88 or 99")]
         public int? ENDMO { get; set; }
 
 

--- a/src/UDS.Net.Forms/Models/UDS4/A4aTreatment.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A4aTreatment.cs
@@ -36,7 +36,7 @@ namespace UDS.Net.Forms.Models.UDS4
         [ProhibitedCharacters]
         public string? NCTNUM { get; set; }
 
-        [RegularExpression("^([1-9]|1[0-2]|88|99)$", ErrorMessage = "Valid range is 0-36 or 88 or 99")]
+        [Range(1, 12)]
         public int? STARTMO { get; set; }
 
         public int? STARTYEAR { get; set; }

--- a/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml
@@ -46,7 +46,10 @@
                         End date <span class="text-gray-400 italic">(month/year)</span>
                     </div>
                     <div>
-                        <span class="text-gray-400 italic">(88/8888 = ongoing | 99/9999 = unknown)</span>
+                        <span class="text-gray-400 italic">(88/8888 = ongoing)</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-400 italic">(99/9999 = unknown)</span>
                     </div>
                 </th>
                 <th class="px-6 py-3 text-left text-base font-semibold text-gray-900">
@@ -147,7 +150,12 @@
                     <div>
                         End date <span class="text-gray-400 italic">(month/year)</span>
                     </div>
-                    <span class="text-gray-400 italic">(88/8888 = ongoing | 99/9999 = unknown)</span>
+                    <div>
+                        <span class="text-gray-400 italic">(88/8888 = ongoing)</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-400 italic">(99/9999 = unknown)</span>
+                    </div>
                 </th>
                 <th class="px-6 py-3 text-left text-base font-semibold text-gray-900">
                     How was the treatment provided?

--- a/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml
@@ -42,7 +42,12 @@
                     Start date <span class="text-gray-400 italic">(month/year)</span>
                 </th>
                 <th class="px-6 py-3 text-left text-base font-semibold text-gray-900">
-                    End date <span class="text-gray-400 italic">(month/year)</span>
+                    <div>
+                        End date <span class="text-gray-400 italic">(month/year)</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-400 italic">(88/8888 = ongoing | 99/9999 = unknown)</span>
+                    </div>
                 </th>
                 <th class="px-6 py-3 text-left text-base font-semibold text-gray-900">
                     How was the treatment provided?
@@ -139,7 +144,10 @@
                     Start date <span class="text-gray-400 italic">(month/year)</span>
                 </th>
                 <th class="px-6 py-3 text-left text-base font-semibold text-gray-900">
-                    End date <span class="text-gray-400 italic">(month/year)</span>
+                    <div>
+                        End date <span class="text-gray-400 italic">(month/year)</span>
+                    </div>
+                    <span class="text-gray-400 italic">(88/8888 = ongoing | 99/9999 = unknown)</span>
                 </th>
                 <th class="px-6 py-3 text-left text-base font-semibold text-gray-900">
                     How was the treatment provided?


### PR DESCRIPTION
Fixes: #249

## A4A form: Current tables do not allow for 88 and 99 end month inputs and 8888 and 9999 end yearinputs in table

Add 88 and 99 for start month inputs and 8888 and 9999 for start year input options for each row in table

### Newly acceptable inputs for end month and end year in PR
![image](https://github.com/user-attachments/assets/8a7895b8-4494-4e4a-90c1-825bbd39622d)


### Checklist
- [x] can input 88 or 99 for any end month input
- [x] can input 8888 or 9999 for end year input