### PR TITLE
Add js behavior for MENARCHE

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.1</ReleaseVersion>
+		<ReleaseVersion>6.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
@@ -540,29 +540,47 @@ namespace UDS.Net.Forms.Models.UDS4
         [MaxLength(60)]
         [RequiredIf(nameof(NOMENSOTH), "true", ErrorMessage = "Please specify.")]
         public string? NOMENSOTHX { get; set; }
+
         [Display(Name = "Has the participant taken female hormone replacement pills or patches (e.g. estrogen)?")]
         [RegularExpression("^(0|1|9)$", ErrorMessage = "Valid range is 0, 1, or 9")]
+        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
+        [RequiredIf(nameof(MENARCHE), "99", ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
         public int? HRT { get; set; }
+
         [Display(Name = "Total number of years participant has taken female hormone replacement pills")]
         [RegularExpression("^(\\d|[1-6]\\d|70|99)$", ErrorMessage = "Valid range is 0-70 or 99")]
+        [RequiredIf(nameof(HRT), "1", ErrorMessage = "Required if HRT = Yes")]
         public int? HRTYEARS { get; set; }
+
         [Display(Name = "Age at first use of female hormone replacement pills")]
         [RegularExpression("^(1\\d|[2-6]\\d|70|99)$", ErrorMessage = "Valid range is 10-70 or 99")]
+        [RequiredIf(nameof(HRT), "1", ErrorMessage = "Required if HRT = Yes")]
         public int? HRTSTRTAGE { get; set; }
+
         [Display(Name = "Age at last use of female hormone replacement pills")]
         [RegularExpression("^(1\\d|[2-6]\\d|70||88|99)$", ErrorMessage = "Valid range is 10-70 or 88 or 99")]
+        [RequiredIf(nameof(HRT), "1", ErrorMessage = "Required if HRT = Yes")]
         public int? HRTENDAGE { get; set; }
+
         [Display(Name = "Has the participant ever taken birth control pills?")]
         [RegularExpression("^(0|1|9)$", ErrorMessage = "Valid range is 0, 1, or 9")]
+        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
+        [RequiredIf(nameof(MENARCHE), "99", ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
         public int? BCPILLS { get; set; }
+
         [Display(Name = "Total number of years participant has taken birth control pills")]
         [RegularExpression("^(\\d|[1-4]\\d|50|99)$", ErrorMessage = "Valid range is 0-50 or 99")]
+        [RequiredIf(nameof(BCPILLS), "1", ErrorMessage = "Required if BCPILLS = Yes")]
         public int? BCPILLSYR { get; set; }
+
         [Display(Name = "Age at first use of birth control pills")]
         [RegularExpression("^(1\\d|[2-6]\\d|70|99)$", ErrorMessage = "Valid range is 10-70 or 99")]
+        [RequiredIf(nameof(BCPILLS), "1", ErrorMessage = "Required if BCPILLS = Yes")]
         public int? BCSTARTAGE { get; set; }
+
         [Display(Name = "Age at last use of birth control pills")]
         [RegularExpression("^(1\\d|[2-6]\\d|70||88|99)$", ErrorMessage = "Valid range is 10-70 or 88 or 99")]
+        [RequiredIf(nameof(BCPILLS), "1", ErrorMessage = "Required if BCPILLS = Yes")]
         public int? BCENDAGE { get; set; }
 
         [RequiredIf(nameof(HEADIMP), "1", ErrorMessage = "Please indicate at least one sources of exposure.")]

--- a/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
@@ -515,6 +515,8 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? MENARCHE { get; set; }
         [Display(Name = "How old was the participant when they had their last menstrual period?")]
         [RegularExpression("^(1\\d|[2-6]\\d|70||88|99)$", ErrorMessage = "Valid range is 10-70 or 88 or 99")]
+        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
+        [RequiredIf(nameof(MENARCHE), "99", ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
         public int? NOMENSAGE { get; set; }
         [Display(Name = "Participant has stopped having menstrual periods due to natural menopause")]
         public bool? NOMENSNAT { get; set; }

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
@@ -1916,7 +1916,7 @@
                     </label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.MENARCHE"></p>
-                        <input asp-for="@Model.A5D2.MENARCHE" ui-range-behavior="Model.MENARCHEBehavior" />
+                        <input asp-for="@Model.A5D2.MENARCHE" />
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="A5D2.MENARCHE"></span>
                     </div>
                 </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
@@ -1927,7 +1927,7 @@
                     </label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.MENARCHE"></p>
-                        <input asp-for="@Model.A5D2.MENARCHE" />
+                        <input asp-for="@Model.A5D2.MENARCHE" ui-range-behavior="Model.MENARCHEBehavior"/>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="A5D2.MENARCHE"></span>
                     </div>
                 </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
@@ -1419,21 +1419,6 @@ public class A5D2Model : FormPageModel
          },
     };
 
-    public UIRangeToggle MENARCHEBehavior = new UIRangeToggle
-    {
-        Low = 5,
-        High = 99,
-        UIBehavior = new UIBehavior
-        {
-            PropertyAttributes = new List<UIPropertyAttributes>
-                {
-                    new UIEnableAttribute("A5D2.NOMENSAGE"),
-                    new UIEnableAttribute("A5D2.HRT"),
-                    new UIEnableAttribute("A5D2.BCPILLS"),
-                },
-        }
-    };
-
     public UIRangeToggle NOMESAGEBehavior = new UIRangeToggle
     {
         Low = 10,

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
@@ -1419,6 +1419,20 @@ public class A5D2Model : FormPageModel
          },
     };
 
+    public UIRangeToggle MENARCHEBehavior = new UIRangeToggle
+    {
+        Low = 5,
+        High = 99,
+        UIBehavior = new UIBehavior
+        {
+            PropertyAttributes = new List<UIPropertyAttributes>
+                {
+                    new UIEnableAttribute("A5D2.HRT"),
+                    new UIEnableAttribute("A5D2.BCPILLS"),
+                },
+        }
+    };
+
     public List<RadioListItem> BasicYesNoListItems { get; set; } = new List<RadioListItem>
     {
         new RadioListItem("No", "0"),

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.1</Version>
+		<Version>6.0.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.1</ReleaseVersion>
+		<ReleaseVersion>6.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/wwwroot/js/A5D2.js
+++ b/src/UDS.Net.Forms/wwwroot/js/A5D2.js
@@ -58,6 +58,7 @@ $(document).ready(function () {
 
     NOMENSAGEInput.addEventListener("change", ToggleNOMENSAGECheckboxes)
 
+    MENARCHEInput.addEventListener("change", MENARCHEBehavior)
 
     //On load methods
     toggleDeprTreat();

--- a/src/UDS.Net.Forms/wwwroot/js/A5D2.js
+++ b/src/UDS.Net.Forms/wwwroot/js/A5D2.js
@@ -1,30 +1,50 @@
 ﻿/*Implemented on questions 6a1 6a2 and 6a3 form A5D2*/
 
 $(document).ready(function () {
-  var majorDepRadios = Array.from(document.getElementsByName("A5D2.MAJORDEP"));
-  var otherDepRadios = Array.from(document.getElementsByName("A5D2.OTHERDEP"));
-  var deprTreatRadios = Array.from(
-    document.getElementsByName("A5D2.DEPRTREAT"),
-  );
 
-  function toggleDeprTreat() {
-    const recentMajorDep = majorDepRadios.some(
-      (radio) => radio.checked && radio.value == "1",
+    //element selectors
+    var majorDepRadios = Array.from(document.getElementsByName("A5D2.MAJORDEP"));
+    var otherDepRadios = Array.from(document.getElementsByName("A5D2.OTHERDEP"));
+    var deprTreatRadios = Array.from(document.getElementsByName("A5D2.DEPRTREAT"));
+    let NOMENSAGEInput = document.getElementById("A5D2_NOMENSAGE");
+    let MENARCHEInput = document.getElementById("A5D2_MENARCHE");
+
+
+
+    function toggleDeprTreat() {
+        const recentMajorDep = majorDepRadios.some(
+            (radio) => radio.checked && radio.value == "1",
+        );
+        const recentOtherDep = otherDepRadios.some(
+            (radio) => radio.checked && radio.value == "1",
+        );
+
+        deprTreatRadios.forEach((radio) => {
+            radio.disabled = !(recentMajorDep || recentOtherDep);
+        });
+    }
+
+    function MENARCHEBehavior() {
+        if (MENARCHEInput.value >= 5 && MENARCHEInput.value <= 25 | MENARCHEInput.value == 99) {
+            NOMENSAGEInput.disabled = false
+        } else {
+            NOMENSAGEInput.disabled = true
+            NOMENSAGEInput.value = "";
+        }
+    }
+
+    //Event listeners
+    majorDepRadios.forEach((radio) =>
+        radio.addEventListener("change", toggleDeprTreat),
     );
-    const recentOtherDep = otherDepRadios.some(
-      (radio) => radio.checked && radio.value == "1",
+
+    otherDepRadios.forEach((radio) =>
+        radio.addEventListener("change", toggleDeprTreat),
     );
 
-    deprTreatRadios.forEach((radio) => {
-      radio.disabled = !(recentMajorDep || recentOtherDep);
-    });
-  }
-  majorDepRadios.forEach((radio) =>
-    radio.addEventListener("change", toggleDeprTreat),
-  );
-  otherDepRadios.forEach((radio) =>
-    radio.addEventListener("change", toggleDeprTreat),
-  );
+    MENARCHEInput.addEventListener("change", MENARCHEBehavior)
 
-  toggleDeprTreat();
+    //On load methods
+    toggleDeprTreat();
+    MENARCHEBehavior();
 });

--- a/src/UDS.Net.Forms/wwwroot/js/A5D2.js
+++ b/src/UDS.Net.Forms/wwwroot/js/A5D2.js
@@ -2,66 +2,67 @@
 
 $(document).ready(function () {
 
-    //element selectors
-    var majorDepRadios = Array.from(document.getElementsByName("A5D2.MAJORDEP"));
-    var otherDepRadios = Array.from(document.getElementsByName("A5D2.OTHERDEP"));
-    var deprTreatRadios = Array.from(document.getElementsByName("A5D2.DEPRTREAT"));
-    let NOMENSAGEInput = document.getElementById("A5D2_NOMENSAGE");
-    let MENARCHEInput = document.getElementById("A5D2_MENARCHE");
+  //element selectors
+  var majorDepRadios = Array.from(document.getElementsByName("A5D2.MAJORDEP"));
+  var otherDepRadios = Array.from(document.getElementsByName("A5D2.OTHERDEP"));
+  var deprTreatRadios = Array.from(document.getElementsByName("A5D2.DEPRTREAT"));
+  let NOMENSAGEInput = document.getElementById("A5D2_NOMENSAGE");
+  let MENARCHEInput = document.getElementById("A5D2_MENARCHE");
 
-    //Get NOMENSAGE checkboxes
-    let NOMENSAGECheckboxSection = document.getElementById("NOMENSAGECheckboxSection");
-    let NOMENSAGECheckboxes = NOMENSAGECheckboxSection.querySelectorAll('input[type="checkbox"]');
+  //Get NOMENSAGE checkboxes
+  let NOMENSAGECheckboxSection = document.getElementById("NOMENSAGECheckboxSection");
+  let NOMENSAGECheckboxes = NOMENSAGECheckboxSection.querySelectorAll('input[type="checkbox"]');
 
-    function toggleDeprTreat() {
-        const recentMajorDep = majorDepRadios.some(
-            (radio) => radio.checked && radio.value == "1",
-        );
-        const recentOtherDep = otherDepRadios.some(
-            (radio) => radio.checked && radio.value == "1",
-        );
-
-        deprTreatRadios.forEach((radio) => {
-            radio.disabled = !(recentMajorDep || recentOtherDep);
-        });
-    }
-
-    function MENARCHEBehavior() {
-        if (MENARCHEInput.value >= 5 && MENARCHEInput.value <= 25 | MENARCHEInput.value == 99) {
-            NOMENSAGEInput.disabled = false
-        } else {
-            NOMENSAGEInput.disabled = true
-            NOMENSAGEInput.value = "";
-        }
-    }
-
-    function ToggleNOMENSAGECheckboxes() {
-        if (NOMENSAGEInput.value >= 10 && NOMENSAGEInput.value <= 70 | NOMENSAGEInput.value == 99) {
-            NOMENSAGECheckboxes.forEach((checkbox) => {
-                checkbox.disabled = false
-            })
-        } else {
-            NOMENSAGECheckboxes.forEach((checkbox) => {
-                checkbox.disabled = true
-            })
-        }
-    }
-
-    //Event listeners
-    majorDepRadios.forEach((radio) =>
-        radio.addEventListener("change", toggleDeprTreat),
+  function toggleDeprTreat() {
+    const recentMajorDep = majorDepRadios.some(
+      (radio) => radio.checked && radio.value == "1",
+    );
+    const recentOtherDep = otherDepRadios.some(
+      (radio) => radio.checked && radio.value == "1",
     );
 
-    otherDepRadios.forEach((radio) =>
-        radio.addEventListener("change", toggleDeprTreat),
-    );
+    deprTreatRadios.forEach((radio) => {
+      radio.disabled = !(recentMajorDep || recentOtherDep);
+    });
+  }
 
-    NOMENSAGEInput.addEventListener("change", ToggleNOMENSAGECheckboxes)
+  function MENARCHEBehavior() {
+    if (MENARCHEInput.value >= 5 && MENARCHEInput.value <= 25 | MENARCHEInput.value == 99) {
+      NOMENSAGEInput.disabled = false
+    } else {
+      NOMENSAGEInput.disabled = true
+      NOMENSAGEInput.value = "";
+      ToggleNOMENSAGECheckboxes();
+    }
+  }
 
-    MENARCHEInput.addEventListener("change", MENARCHEBehavior)
+  function ToggleNOMENSAGECheckboxes() {
+    if (NOMENSAGEInput.value >= 10 && NOMENSAGEInput.value <= 70 | NOMENSAGEInput.value == 99) {
+      NOMENSAGECheckboxes.forEach((checkbox) => {
+        checkbox.disabled = false
+      })
+    } else {
+      NOMENSAGECheckboxes.forEach((checkbox) => {
+        checkbox.disabled = true
+      })
+    }
+  }
 
-    //On load methods
-    toggleDeprTreat();
-    MENARCHEBehavior();
-    ToggleNOMENSAGECheckboxes()
+  //Event listeners
+  majorDepRadios.forEach((radio) =>
+    radio.addEventListener("change", toggleDeprTreat),
+  );
+
+  otherDepRadios.forEach((radio) =>
+    radio.addEventListener("change", toggleDeprTreat),
+  );
+
+  NOMENSAGEInput.addEventListener("change", ToggleNOMENSAGECheckboxes)
+
+  MENARCHEInput.addEventListener("change", MENARCHEBehavior)
+
+  //On load methods
+  toggleDeprTreat();
+  MENARCHEBehavior();
+  ToggleNOMENSAGECheckboxes()
 });

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.1</ReleaseVersion>
+		<ReleaseVersion>6.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.1</Version>
+		<Version>6.0.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.1</ReleaseVersion>
+		<ReleaseVersion>6.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.1</Version>
+		<Version>6.0.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.1</ReleaseVersion>
+		<ReleaseVersion>6.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.1</ReleaseVersion>
+		<ReleaseVersion>6.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -3,19 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services", "UDS.Net.Services\UDS.Net.Services.csproj", "{2859D284-F0ED-47CE-9B1D-70DE32451D6D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Services", "UDS.Net.Services\UDS.Net.Services.csproj", "{2859D284-F0ED-47CE-9B1D-70DE32451D6D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms.Tests", "UDS.Net.Forms.Tests\UDS.Net.Forms.Tests.csproj", "{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Forms.Tests", "UDS.Net.Forms.Tests\UDS.Net.Forms.Tests.csproj", "{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", "UDS.Net.Web.MVC.Services\UDS.Net.Web.MVC.Services.csproj", "{5B18B13C-475D-4F58-947B-A80F49CF3F7C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Web.MVC.Services", "UDS.Net.Web.MVC.Services\UDS.Net.Web.MVC.Services.csproj", "{5B18B13C-475D-4F58-947B-A80F49CF3F7C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
 EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{6817EBB4-66CB-445E-B155-FACEBC97A344}"
+Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{6817EBB4-66CB-445E-B155-FACEBC97A344}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,16 +25,28 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{99F6A944-AD72-42F0-BBB1-887449A2C8E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{99F6A944-AD72-42F0-BBB1-887449A2C8E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99F6A944-AD72-42F0-BBB1-887449A2C8E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99F6A944-AD72-42F0-BBB1-887449A2C8E1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2859D284-F0ED-47CE-9B1D-70DE32451D6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2859D284-F0ED-47CE-9B1D-70DE32451D6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2859D284-F0ED-47CE-9B1D-70DE32451D6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2859D284-F0ED-47CE-9B1D-70DE32451D6D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5B18B13C-475D-4F58-947B-A80F49CF3F7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5B18B13C-475D-4F58-947B-A80F49CF3F7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B18B13C-475D-4F58-947B-A80F49CF3F7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B18B13C-475D-4F58-947B-A80F49CF3F7C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{332BFB18-1431-4572-BE96-757D0221FBCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{332BFB18-1431-4572-BE96-757D0221FBCE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6817EBB4-66CB-445E-B155-FACEBC97A344}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6817EBB4-66CB-445E-B155-FACEBC97A344}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6817EBB4-66CB-445E-B155-FACEBC97A344}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
resolves: #251

## Form A5D2 NOMENSAGE input should only be enabled and required if MENARCHE is within range 5-25 or 99
- [x] inputting a value of 5 - 25 or 99 will enable the NOMENSAGE field
- [x] inputting a non valid value will disable the NOMENSAGE input 
- [x] Finalizing a form with a MENARCHE input of 5 - 25 or 99 and a null value for NOMENSAGE will result in an error message

### Valid value, NOMENSAGE enabled
![image](https://github.com/user-attachments/assets/e22fe838-668f-4503-bfc1-52af9e277e13)

### Valid value, NOMENSAGE disabled
![image](https://github.com/user-attachments/assets/09ddaf01-5f85-4c89-8ff9-a0660778542e)

### valid value, NOMENSAGE not answered
![image](https://github.com/user-attachments/assets/a720ea2f-7b4c-4873-a938-ee488457d924)
