### PR TITLE
FormPageModel uses Participation Service

### DIFF
--- a/src/UDS.Net.Forms.Tests/Services/VisitService.cs
+++ b/src/UDS.Net.Forms.Tests/Services/VisitService.cs
@@ -93,6 +93,16 @@ namespace UDS.Net.Forms.Tests.Services
         {
             throw new NotImplementedException();
         }
+
+        public Task<string> GetNextFormId(string username, int visitId, string currentFormId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<Form>> SortForms(string username, List<Form> forms)
+        {
+            throw new NotImplementedException();
+        }
     }
 }
 

--- a/src/UDS.Net.Forms.Tests/Services/VisitService.cs
+++ b/src/UDS.Net.Forms.Tests/Services/VisitService.cs
@@ -94,12 +94,12 @@ namespace UDS.Net.Forms.Tests.Services
             throw new NotImplementedException();
         }
 
-        public Task<string> GetNextFormId(string username, int visitId, string currentFormId)
+        public Task<string> GetNextFormKind(string username, int visitId, string currentFormKind)
         {
             throw new NotImplementedException();
         }
 
-        public Task<List<Form>> SortForms(string username, List<Form> forms)
+        public Task<List<string>> GetFormOrder(string username, int visitId)
         {
             throw new NotImplementedException();
         }

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>5.0.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
+		<ReleaseVersion>6.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
+++ b/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
@@ -34,9 +34,9 @@ namespace UDS.Net.Forms.Models.PageModels
                 if (Visit != null)
                 {
                     if (Visit.Participation != null)
-                        return $"Participant {Visit.Participation.LegacyId} Visit {Visit.VISITNUM} {Visit.PACKET}";
+                        return $"Participant {Visit.Participation.LegacyId} Visit {Visit.VISITNUM} {Visit.PACKET.GetDescription()}";
                     else
-                        return $"Participant {Visit.ParticipationId} Visit {Visit.VISITNUM} {Visit.PACKET}";
+                        return $"Participant {Visit.ParticipationId} Visit {Visit.VISITNUM} {Visit.PACKET.GetDescription()}";
                 }
                 return "";
             }
@@ -61,7 +61,7 @@ namespace UDS.Net.Forms.Models.PageModels
 
             Visit = visit.ToVM();
 
-            var participation = await _participationService.GetById(User.Identity.Name, visit.ParticipationId);
+            var participation = await _participationService.GetById(User.Identity.Name, visit.ParticipationId, false);
 
             if (participation == null)
                 return NotFound();
@@ -132,7 +132,7 @@ namespace UDS.Net.Forms.Models.PageModels
 
             Visit = visit.ToVM();
 
-            var participation = await _participationService.GetById(User.Identity.Name, visit.ParticipationId);
+            var participation = await _participationService.GetById(User.Identity.Name, visit.ParticipationId, false);
 
             if (participation == null)
                 return NotFound();

--- a/src/UDS.Net.Forms/Models/PageModels/VisitPageModel.cs
+++ b/src/UDS.Net.Forms/Models/PageModels/VisitPageModel.cs
@@ -54,6 +54,21 @@ namespace UDS.Net.Forms.Models
             Visit = visit.ToVM();
             Visit.Participation = participation.ToVM();
 
+            // Re-order forms
+            if (Visit.Forms != null)
+            {
+                // Sort forms
+                var ordering = await _visitService.GetFormOrder(User.Identity.Name, id.Value);
+                List<FormModel> forms = new List<FormModel>();
+                foreach (var kind in ordering)
+                {
+                    var form = Visit.Forms.Where(f => f.Kind == kind).FirstOrDefault();
+                    if (form != null)
+                        forms.Add(form);
+                }
+                Visit.Forms = forms;
+            }
+
             return Page();
         }
     }

--- a/src/UDS.Net.Forms/Models/PageModels/VisitPageModel.cs
+++ b/src/UDS.Net.Forms/Models/PageModels/VisitPageModel.cs
@@ -24,7 +24,7 @@ namespace UDS.Net.Forms.Models
             {
                 if (Visit != null)
                 {
-                    return $"Participant {Visit.Participation.LegacyId} Visit {Visit.VISITNUM}";
+                    return $"Participant {Visit.Participation.LegacyId} Visit {Visit.VISITNUM} {Visit.PACKET.GetDescription()}";
                 }
                 return "";
             }

--- a/src/UDS.Net.Forms/Pages/Participations/Details.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/Participations/Details.cshtml.cs
@@ -24,7 +24,7 @@ namespace UDS.Net.Forms.Pages.Participations
             if (id == null)
                 return NotFound();
 
-            var participation = await _participationService.GetById("", id.Value);
+            var participation = await _participationService.GetById(User.Identity.Name, id.Value, true);
 
             if (participation == null)
                 return NotFound();

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml.cs
@@ -411,12 +411,10 @@ namespace UDS.Net.Forms.Pages.UDS4
             } }
         };
 
-        public A1Model(IVisitService visitService, ILookupService lookupService) : base(visitService, "A1")
+        public A1Model(IVisitService visitService, IParticipationService participationService, ILookupService lookupService) : base(visitService, participationService, "A1")
         {
             _lookupService = lookupService;
         }
-
-
 
         public async Task<IActionResult> OnGetAsync(int? id)
         {

--- a/src/UDS.Net.Forms/Pages/UDS4/A1a.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1a.cshtml.cs
@@ -12,7 +12,7 @@ namespace UDS.Net.Forms.Pages.UDS4
         [BindProperty]
         public A1a A1a { get; set; } = default!;
 
-        public A1aModel(IVisitService visitService) : base(visitService, "A1a")
+        public A1aModel(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "A1a")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/A2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A2.cshtml.cs
@@ -139,7 +139,7 @@ namespace UDS.Net.Forms.Pages.UDS4
 
 
 
-        public A2Model(IVisitService visitService) : base(visitService, "A2")
+        public A2Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "A2")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/A3.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A3.cshtml.cs
@@ -20,7 +20,7 @@ namespace UDS.Net.Forms.Pages.UDS4
         [BindProperty]
         public A3 A3 { get; set; } = default!;
 
-        public A3Model(IVisitService visitService) : base(visitService, "A3")
+        public A3Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "A3")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4.cshtml.cs
@@ -38,7 +38,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             new RadioListItem("Yes", "1")
         };
 
-        public A4Model(IVisitService visitService, ILookupService lookupService) : base(visitService, "A4")
+        public A4Model(IVisitService visitService, IParticipationService participationService, ILookupService lookupService) : base(visitService, participationService, "A4")
         {
             _lookupService = lookupService;
         }

--- a/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml.cs
@@ -76,7 +76,7 @@ namespace UDS.Net.Forms.Pages.UDS4
         };
 
 
-        public A4aModel(IVisitService visitService) : base(visitService, "A4a")
+        public A4aModel(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "A4a")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
@@ -17,7 +17,7 @@ public class A5D2Model : FormPageModel
     [BindProperty]
     public A5D2 A5D2 { get; set; } = default!;
 
-    public A5D2Model(IVisitService visitService) : base(visitService, "A5D2")
+    public A5D2Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "A5D2")
     {
     }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B1.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B1.cshtml.cs
@@ -39,7 +39,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             { "9", new UIBehavior { PropertyAttribute = new UIDisableAttribute("B1.HEARWAID") } }
         };
 
-        public B1Model(IVisitService visitService) : base(visitService, "B1")
+        public B1Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B1")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B3.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B3.cshtml.cs
@@ -423,7 +423,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             { "8", new UIBehavior { PropertyAttribute = new UIEnableAttribute("B3.BRADYKIX") } },
         };
 
-        public B3Model(IVisitService visitService) : base(visitService, "B3")
+        public B3Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B3")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B4.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B4.cshtml.cs
@@ -35,7 +35,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             new RadioListItem("Severe", "3"),
         };
 
-        public B4Model(IVisitService visitService) : base(visitService, "B4")
+        public B4Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B4")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B5.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B5.cshtml.cs
@@ -130,7 +130,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             { "9", new UIBehavior { PropertyAttribute = new UIDisableAttribute("B5.APPSEV") } }
         };
 
-        public B5Model(IVisitService visitService) : base(visitService, "B5")
+        public B5Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B5")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B6.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B6.cshtml.cs
@@ -32,7 +32,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             new RadioListItem("Did not answer", "9")
         };
 
-        public B6Model(IVisitService visitService) : base(visitService, "B6")
+        public B6Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B6")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B7.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B7.cshtml.cs
@@ -28,7 +28,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             new RadioListItem("Unknown", "9")
         };
 
-        public B7Model(IVisitService visitService) : base(visitService, "B7")
+        public B7Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B7")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B8.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B8.cshtml.cs
@@ -263,7 +263,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             } }
         };
 
-        public B8Model(IVisitService visitService) : base(visitService, "B8")
+        public B8Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B8")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/B9.cshtml.cs
@@ -509,7 +509,7 @@ namespace UDS.Net.Forms.Pages.UDS4
              } },
         };
 
-        public B9Model(IVisitService visitService) : base(visitService, "B9")
+        public B9Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "B9")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/C2.cshtml.cs
@@ -617,7 +617,7 @@ namespace UDS.Net.Forms.Pages.UDS4
             }
         };
 
-        public C2Model(IVisitService visitService) : base(visitService, "C2")
+        public C2Model(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "C2")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml.cs
@@ -19,7 +19,7 @@ namespace UDS.Net.Forms.Pages.UDS4
         [BindProperty]
         public D1a D1a { get; set; } = default!;
 
-        public D1aModel(IVisitService visitService) : base(visitService, "D1a")
+        public D1aModel(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "D1a")
         {
         }
 

--- a/src/UDS.Net.Forms/Pages/UDS4/D1b.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1b.cshtml.cs
@@ -18,7 +18,7 @@ namespace UDS.Net.Forms.Pages.UDS4
         [BindProperty]
         public D1b D1b { get; set; } = default!;
 
-        public D1bModel(IVisitService visitService) : base(visitService, "D1b")
+        public D1bModel(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService, "D1b")
         {
         }
 

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.0-preview.2</Version>
+		<Version>6.0.0-preview.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.0-preview.4</Version>
+		<Version>6.0.0-preview.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>5.0.2</Version>
+		<Version>6.0.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>5.0.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.0-preview.3</Version>
+		<Version>6.0.0-preview.4</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.0-preview.5</Version>
+		<Version>6.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
+		<ReleaseVersion>6.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.0-preview.1</Version>
+		<Version>6.0.0-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>5.0.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
+		<ReleaseVersion>6.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/IParticipationService.cs
+++ b/src/UDS.Net.Services/IParticipationService.cs
@@ -9,6 +9,7 @@ namespace UDS.Net.Services
     public interface IParticipationService : IService<Participation>
     {
         Task<Participation> GetByLegacyId(string username, string legacyId);
+        Task<Participation> GetById(string username, int id, bool includeVisits = false);
 
         Task<Milestone> AddMilestone(int participationId, Milestone milestone);
         Task<Milestone> UpdateMilestone(int id, int formId, Milestone milestone);

--- a/src/UDS.Net.Services/IVisitService.cs
+++ b/src/UDS.Net.Services/IVisitService.cs
@@ -10,9 +10,9 @@ namespace UDS.Net.Services
 
         Task<Visit> UpdateForm(string username, Visit entity, string formId);
 
-        Task<List<Form>> SortForms(string username, List<Form> forms);
+        Task<List<string>> GetFormOrder(string username, int visitId);
 
-        Task<string> GetNextFormId(string username, int visitId, string currentFormId);
+        Task<string> GetNextFormKind(string username, int visitId, string currentFormKind);
 
         Task<int> GetNextVisitNumber(string username, int participationId);
 

--- a/src/UDS.Net.Services/IVisitService.cs
+++ b/src/UDS.Net.Services/IVisitService.cs
@@ -10,6 +10,10 @@ namespace UDS.Net.Services
 
         Task<Visit> UpdateForm(string username, Visit entity, string formId);
 
+        Task<List<Form>> SortForms(string username, List<Form> forms);
+
+        Task<string> GetNextFormId(string username, int visitId, string currentFormId);
+
         Task<int> GetNextVisitNumber(string username, int participationId);
 
         Task<int> GetVisitCountByVersion(string username, int participationId, string version);

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.0-preview.4</Version>
+		<Version>6.0.0-preview.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.0-preview.1</Version>
+		<Version>6.0.0-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>5.0.2</Version>
+		<Version>6.0.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>5.0.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.0-preview.3</Version>
+		<Version>6.0.0-preview.4</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.0-preview.2</Version>
+		<Version>6.0.0-preview.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.0-preview.5</Version>
+		<Version>6.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
+		<ReleaseVersion>6.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Web.MVC.Services/ParticipationService.cs
+++ b/src/UDS.Net.Web.MVC.Services/ParticipationService.cs
@@ -65,6 +65,9 @@ namespace UDS.Net.Web.MVC.Services
 
         public async Task<Participation> GetById(string username, int id, bool includeVisits = false)
         {
+            if (includeVisits)
+                return await GetById(username, id);
+
             var participationDto = await _apiClient.ParticipationClient.Get(id); // Other services can use includeVisits to determine whether the underlying service should include visits or not
 
             if (participationDto != null)

--- a/src/UDS.Net.Web.MVC.Services/ParticipationService.cs
+++ b/src/UDS.Net.Web.MVC.Services/ParticipationService.cs
@@ -63,6 +63,17 @@ namespace UDS.Net.Web.MVC.Services
             }
         }
 
+        public async Task<Participation> GetById(string username, int id, bool includeVisits = false)
+        {
+            var participationDto = await _apiClient.ParticipationClient.Get(id); // Other services can use includeVisits to determine whether the underlying service should include visits or not
+
+            if (participationDto != null)
+            {
+                return participationDto.ToDomain(username);
+            }
+            throw new Exception("Participation not found.");
+        }
+
         public async Task<IEnumerable<Participation>> List(string username, int pageSize = 10, int pageIndex = 1)
         {
             var participationDtos = await _apiClient.ParticipationClient.Get(pageSize, pageIndex);

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.0-preview.1</Version>
+		<Version>6.0.0-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,20 +4,20 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.0-preview.5</Version>
+		<Version>6.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
+		<ReleaseVersion>6.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />
 		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0" />
-		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Services\UDS.Net.Services.csproj" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>5.0.2</Version>
+		<Version>6.0.0-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>5.0.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -10,7 +10,7 @@
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.0-preview.4</Version>
+		<Version>6.0.0-preview.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.0-preview.2</Version>
+		<Version>6.0.0-preview.4</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/VisitService.cs
+++ b/src/UDS.Net.Web.MVC.Services/VisitService.cs
@@ -146,6 +146,35 @@ namespace UDS.Net.Web.MVC.Services
             else
                 throw new NotImplementedException("The developer must update with functionality to support pre-UDS version 4.");
         }
+
+        public async Task<string> GetNextFormId(string username, int visitId, string currentFormId)
+        {
+            var visit = await GetById(username, visitId);
+
+            string nextFormId = "";
+
+            for (int i = 0; i < visit.Forms.Count(); i++)
+            {
+                if (visit.Forms[i].Kind == currentFormId)
+                {
+                    // check if there is a next form
+                    if (i + 1 < visit.Forms.Count())
+                    {
+                        nextFormId = visit.Forms[i + 1].Kind;
+                        break;
+                    }
+                }
+
+            }
+
+            return nextFormId;
+        }
+
+        public async Task<List<Form>> SortForms(string username, List<Form> forms)
+        {
+            // In this implementation we are sorting by kind alphabetically, but other organizations may want the flexibilty to order forms by another parameter.
+            return forms.OrderBy(f => f.Kind).ToList();
+        }
     }
 }
 

--- a/src/UDS.Net.Web.MVC.Services/VisitService.cs
+++ b/src/UDS.Net.Web.MVC.Services/VisitService.cs
@@ -147,20 +147,20 @@ namespace UDS.Net.Web.MVC.Services
                 throw new NotImplementedException("The developer must update with functionality to support pre-UDS version 4.");
         }
 
-        public async Task<string> GetNextFormId(string username, int visitId, string currentFormId)
+        public async Task<string> GetNextFormKind(string username, int visitId, string currentFormKind)
         {
-            var visit = await GetById(username, visitId);
+            var ordering = await GetFormOrder(username, visitId);
 
             string nextFormId = "";
 
-            for (int i = 0; i < visit.Forms.Count(); i++)
+            for (int i = 0; i < ordering.Count(); i++)
             {
-                if (visit.Forms[i].Kind == currentFormId)
+                if (ordering[i] == currentFormKind)
                 {
                     // check if there is a next form
-                    if (i + 1 < visit.Forms.Count())
+                    if (i + 1 < ordering.Count())
                     {
-                        nextFormId = visit.Forms[i + 1].Kind;
+                        nextFormId = ordering[i + 1];
                         break;
                     }
                 }
@@ -170,10 +170,11 @@ namespace UDS.Net.Web.MVC.Services
             return nextFormId;
         }
 
-        public async Task<List<Form>> SortForms(string username, List<Form> forms)
+        public async Task<List<string>> GetFormOrder(string username, int visitId)
         {
             // In this implementation we are sorting by kind alphabetically, but other organizations may want the flexibilty to order forms by another parameter.
-            return forms.OrderBy(f => f.Kind).ToList();
+            var visit = await GetById(username, visitId);
+            return visit.Forms.OrderBy(f => f.Kind).Select(f => f.Kind).ToList();
         }
     }
 }

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.0-preview.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.0-preview.3</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
+		<ReleaseVersion>6.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
 		<PackageReference Include="UDS.Net.API.Client" Version="4.5.0" />
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />
-		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.3" />
+		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Forms\UDS.Net.Forms.csproj">

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.0-preview.4</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>5.0.2</ReleaseVersion>
+		<ReleaseVersion>6.0.0-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 6.0.0-preview.2
+		version = 6.0.0-preview.3
 	EndGlobalSection
 EndGlobal

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -3,19 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Services", "UDS.Net.Services\UDS.Net.Services.csproj", "{2859D284-F0ED-47CE-9B1D-70DE32451D6D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services", "UDS.Net.Services\UDS.Net.Services.csproj", "{2859D284-F0ED-47CE-9B1D-70DE32451D6D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Forms.Tests", "UDS.Net.Forms.Tests\UDS.Net.Forms.Tests.csproj", "{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms.Tests", "UDS.Net.Forms.Tests\UDS.Net.Forms.Tests.csproj", "{B1AC7F77-4264-441E-A8C2-847ADFCF8BCF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Web.MVC.Services", "UDS.Net.Web.MVC.Services\UDS.Net.Web.MVC.Services.csproj", "{5B18B13C-475D-4F58-947B-A80F49CF3F7C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", "UDS.Net.Web.MVC.Services\UDS.Net.Web.MVC.Services.csproj", "{5B18B13C-475D-4F58-947B-A80F49CF3F7C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
 EndProject
-Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{6817EBB4-66CB-445E-B155-FACEBC97A344}"
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{4B98485B-9E58-4613-AF6A-186FC4B4D7F6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,10 +47,10 @@ Global
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6817EBB4-66CB-445E-B155-FACEBC97A344}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6817EBB4-66CB-445E-B155-FACEBC97A344}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6817EBB4-66CB-445E-B155-FACEBC97A344}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6817EBB4-66CB-445E-B155-FACEBC97A344}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B98485B-9E58-4613-AF6A-186FC4B4D7F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B98485B-9E58-4613-AF6A-186FC4B4D7F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B98485B-9E58-4613-AF6A-186FC4B4D7F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B98485B-9E58-4613-AF6A-186FC4B4D7F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 5.0.1
+		version = 6.0.0-preview.1
 	EndGlobalSection
 EndGlobal

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 6.0.0-preview.3
+		version = 6.0.0-preview.4
 	EndGlobalSection
 EndGlobal

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 6.0.0-preview.4
+		version = 6.0.0-preview.5
 	EndGlobalSection
 EndGlobal

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 6.0.0-preview.5
+		version = 6.0.0
 	EndGlobalSection
 EndGlobal

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 6.0.0-preview.1
+		version = 6.0.0-preview.2
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fixes https://github.com/UK-SBCoA/COA.UDSv4/issues/63

In our consuming applications of the razor class library we need to display the legacy id, therefore we need the participation service injected into the base FormPageModel. This will also become useful when pre-filling demographic and other information from other systems.