### PR TITLE
Adjust b6 calculations to include prorate scoring

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.6</ReleaseVersion>
+		<ReleaseVersion>6.0.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.6</Version>
+		<Version>6.0.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.6</ReleaseVersion>
+		<ReleaseVersion>6.0.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/wwwroot/js/js_controllers/b6_controller.js
+++ b/src/UDS.Net.Forms/wwwroot/js/js_controllers/b6_controller.js
@@ -16,17 +16,32 @@ export default class extends Controller {
 
     CalculateGDS() {
 
-        let skipCalculation = this.NOGDSInputTarget.checked ? true : false
+        const totalQuestionCount = 15
 
-        //reset values for recalculation
-        this.GDSInputTarget.value = ""
+        let skipCalculation = this.NOGDSInputTarget.checked ? true : false
+        let GDSScore = 0;
+        let unansweredCount = 0
 
         if (!skipCalculation) {
-            this.radioTableTarget.querySelectorAll('input[type="radio"]:checked').forEach((radio) => {
+
+            let checkedRadios = this.radioTableTarget.querySelectorAll('input[type="radio"]:checked')
+
+            checkedRadios.forEach((radio) => {
                 if (Number(radio.value) != 9) {
-                    this.GDSInputTarget.value = Number(this.GDSInputTarget.value) + Number(radio.value)
+                    GDSScore += Number(radio.value)
+                } else {
+                    unansweredCount++
                 }
             })
+
+            //display the total only when all questions have been answered
+            if (checkedRadios.length == totalQuestionCount) {
+                if (unansweredCount == 0) {
+                    this.GDSInputTarget.value = GDSScore
+                } else {
+                    this.GDSInputTarget.value = this.ProrateGDSScore(GDSScore, checkedRadios.length, unansweredCount)
+                }
+            }
         } else {
             this.GDSInputTarget.value = 88
         }
@@ -48,5 +63,9 @@ export default class extends Controller {
             //recalculate GDS with enabled radios
             this.CalculateGDS()
         }
+    }
+
+    ProrateGDSScore(GDSScore, answeredCount, unansweredCount) {
+        return Math.round(GDSScore + ((GDSScore / answeredCount) * unansweredCount))
     }
 }

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.6</ReleaseVersion>
+		<ReleaseVersion>6.0.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.6</Version>
+		<Version>6.0.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.6</ReleaseVersion>
+		<ReleaseVersion>6.0.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.6</Version>
+		<Version>6.0.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.6</ReleaseVersion>
+		<ReleaseVersion>6.0.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.6</ReleaseVersion>
+		<ReleaseVersion>6.0.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves: #277 

## Include prorated scoring for B6
Prorated scoring should be involved in the GDS total score when 1 - 3 questions are 9 (Did not answer). If all questions are answered the GDS score will just be the sum of all answered radio values. 

More details on the GDS prorated scoring can be found on the parent issue card. 

## Scoring chart
Below I will include some pre-assessed prorated scores for expected results when reviewing:

### prorated formula: 
`total score + [(Total score of completed items/# of completed items) * # of unanswered items]`

| total score of completed items | # of completed items |  # of unanswered items | GDS prorated score result (rounded)
| ----------------------------------|------------------------- | -----------------------  | ---------------------------- |
| 1                                                | 12                                | 3                                 | 1
| 2                                                | 13                               | 2                                  | 2
| 3                                                | 14                               | 1                                  | 3
| 5                                                |   12                              |  3                                 |  6
| 6                                                |   13                              |  2                                 |  7
 

### Review checklist
- [x] Prorated scores are correctly calculated
- [x] Prorated scoring is used for GDS score when 1 - 3 questions are marked as 9 
- [x] Prorated scoring is NOT used when there are no values marked as 9
- [x] On a new form, the score will not calculate until all 15 radios have been given a value OR the checkbox at the top of the form is checked to make the GDS total score 88
