### PR TITLE
update validation ranges and related validation

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.8</ReleaseVersion>
+		<ReleaseVersion>6.0.9</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.9</ReleaseVersion>
+		<ReleaseVersion>6.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
@@ -511,12 +511,12 @@ namespace UDS.Net.Forms.Models.UDS4
         [RequiredIfRange(nameof(PSYCDIS), 1, 2, ErrorMessage = "Please specify.")]
         public string? PSYCDISX { get; set; }
         [Display(Name = "How old was the participant when they had their first menstrual period?")]
-        [RegularExpression("^([5-9]|1\\d|2[0-5]|88|99)$", ErrorMessage = "Valid range is 5-25 or 88 or 99")]
+        [RegularExpression("^([5-9]|1\\d|2[0-5]|888|999)$", ErrorMessage = "Valid range is 5-25 or 888 or 999")]
         public int? MENARCHE { get; set; }
         [Display(Name = "How old was the participant when they had their last menstrual period?")]
-        [RegularExpression("^(1\\d|[2-6]\\d|70||88|99)$", ErrorMessage = "Valid range is 10-70 or 88 or 99")]
-        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
-        [RequiredIf(nameof(MENARCHE), "99", ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
+        [RegularExpression("^(1\\d|[2-6]\\d|70||888|999)$", ErrorMessage = "Valid range is 10-70 or 888 or 999")]
+        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 999")]
+        [RequiredIf(nameof(MENARCHE), "999", ErrorMessage = "Required if MENARCHE is 5 - 25 or 999")]
         public int? NOMENSAGE { get; set; }
         [Display(Name = "Participant has stopped having menstrual periods due to natural menopause")]
         public bool? NOMENSNAT { get; set; }
@@ -543,43 +543,43 @@ namespace UDS.Net.Forms.Models.UDS4
 
         [Display(Name = "Has the participant taken female hormone replacement pills or patches (e.g. estrogen)?")]
         [RegularExpression("^(0|1|9)$", ErrorMessage = "Valid range is 0, 1, or 9")]
-        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
-        [RequiredIf(nameof(MENARCHE), "99", ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
+        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 999")]
+        [RequiredIf(nameof(MENARCHE), "999", ErrorMessage = "Required if MENARCHE is 5 - 25 or 999")]
         public int? HRT { get; set; }
 
         [Display(Name = "Total number of years participant has taken female hormone replacement pills")]
-        [RegularExpression("^(\\d|[1-6]\\d|70|99)$", ErrorMessage = "Valid range is 0-70 or 99")]
+        [RegularExpression("^(\\d|[1-8]\\d|90|999)$", ErrorMessage = "Valid range is 0-90 or 999")]
         [RequiredIf(nameof(HRT), "1", ErrorMessage = "Required if HRT = Yes")]
         public int? HRTYEARS { get; set; }
 
         [Display(Name = "Age at first use of female hormone replacement pills")]
-        [RegularExpression("^(1\\d|[2-6]\\d|70|99)$", ErrorMessage = "Valid range is 10-70 or 99")]
+        [RegularExpression("^(1\\d|[2-9]\\d|10\\d|110|999)$", ErrorMessage = "Valid range is 10-110 or 999")]
         [RequiredIf(nameof(HRT), "1", ErrorMessage = "Required if HRT = Yes")]
         public int? HRTSTRTAGE { get; set; }
 
         [Display(Name = "Age at last use of female hormone replacement pills")]
-        [RegularExpression("^(1\\d|[2-6]\\d|70||88|99)$", ErrorMessage = "Valid range is 10-70 or 88 or 99")]
+        [RegularExpression("^(1\\d|[2-9]\\d|10\\d|110|888|999)$", ErrorMessage = "Valid range is 10-110 or 888 or 999")]
         [RequiredIf(nameof(HRT), "1", ErrorMessage = "Required if HRT = Yes")]
         public int? HRTENDAGE { get; set; }
 
         [Display(Name = "Has the participant ever taken birth control pills?")]
         [RegularExpression("^(0|1|9)$", ErrorMessage = "Valid range is 0, 1, or 9")]
-        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
-        [RequiredIf(nameof(MENARCHE), "99", ErrorMessage = "Required if MENARCHE is 5 - 25 or 99")]
+        [RequiredIfRange(nameof(MENARCHE), 5, 25, ErrorMessage = "Required if MENARCHE is 5 - 25 or 999")]
+        [RequiredIf(nameof(MENARCHE), "999", ErrorMessage = "Required if MENARCHE is 5 - 25 or 999")]
         public int? BCPILLS { get; set; }
 
         [Display(Name = "Total number of years participant has taken birth control pills")]
-        [RegularExpression("^(\\d|[1-4]\\d|50|99)$", ErrorMessage = "Valid range is 0-50 or 99")]
+        [RegularExpression("^(\\d|[1-4]\\d|50|999)$", ErrorMessage = "Valid range is 0-50 or 999")]
         [RequiredIf(nameof(BCPILLS), "1", ErrorMessage = "Required if BCPILLS = Yes")]
         public int? BCPILLSYR { get; set; }
 
         [Display(Name = "Age at first use of birth control pills")]
-        [RegularExpression("^(1\\d|[2-6]\\d|70|99)$", ErrorMessage = "Valid range is 10-70 or 99")]
+        [RegularExpression("^(1\\d|[2-6]\\d|70|999)$", ErrorMessage = "Valid range is 10-70 or 999")]
         [RequiredIf(nameof(BCPILLS), "1", ErrorMessage = "Required if BCPILLS = Yes")]
         public int? BCSTARTAGE { get; set; }
 
         [Display(Name = "Age at last use of birth control pills")]
-        [RegularExpression("^(1\\d|[2-6]\\d|70||88|99)$", ErrorMessage = "Valid range is 10-70 or 88 or 99")]
+        [RegularExpression("^(1\\d|[2-6]\\d|70||888|999)$", ErrorMessage = "Valid range is 10-70 or 888 or 999")]
         [RequiredIf(nameof(BCPILLS), "1", ErrorMessage = "Required if BCPILLS = Yes")]
         public int? BCENDAGE { get; set; }
 
@@ -689,7 +689,7 @@ namespace UDS.Net.Forms.Models.UDS4
         }
 
         [RequiredIfRange(nameof(NOMENSAGE), 10, 70, ErrorMessage = "Please indicate at least one reason.")]
-        [RequiredIf(nameof(NOMENSAGE), "99", ErrorMessage = "Please indicate at least one reason.")]
+        [RequiredIf(nameof(NOMENSAGE), "999", ErrorMessage = "Please indicate at least one reason.")]
         [NotMapped]
         public bool? NOMENSAGEStoppedReasonCheckboxes
         {

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
@@ -1919,7 +1919,7 @@
                 <div class="@rowCSS">
                     <label asp-for="A5D2.MENARCHE">
                         <span class="counter invisible"></span><span class="subcounter"></span> @Html.DisplayNameFor(m => m.A5D2.MENARCHE)
-                        <p class="font-bold">(88 = Never had a menstrual period, 999 = Unknown)</p>
+                        <p class="font-bold">(888 = Never had a menstrual period, 999 = Unknown)</p>
                         <p class="font-bold">(IF NEVER HAD A MENSTRUAL PERIOD, SKIP TO 7d)</p>
                     </label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml
@@ -1919,7 +1919,7 @@
                 <div class="@rowCSS">
                     <label asp-for="A5D2.MENARCHE">
                         <span class="counter invisible"></span><span class="subcounter"></span> @Html.DisplayNameFor(m => m.A5D2.MENARCHE)
-                        <p class="font-bold">(88 = Never had a menstrual period, 99 = Unknown)</p>
+                        <p class="font-bold">(88 = Never had a menstrual period, 999 = Unknown)</p>
                         <p class="font-bold">(IF NEVER HAD A MENSTRUAL PERIOD, SKIP TO 7d)</p>
                     </label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
@@ -1933,7 +1933,7 @@
                 <div class="@rowCSS">
                     <label asp-for="A5D2.NOMENSAGE">
                         <span class="subcounter"></span> @Html.DisplayNameFor(m => m.A5D2.NOMENSAGE)
-                        <p class="font-bold">(88 = Still menstrauting, 99 = Unknown)</p>
+                        <p class="font-bold">(888 = Still menstrauting, 999 = Unknown)</p>
                         <p class="font-bold">(IF STILL MENSTRUATING, SKIP TO 7d)</p>
                     </label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
@@ -2076,7 +2076,7 @@
             </div>
             <div class="ml-5">
                 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A5D2.HRTYEARS"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.HRTYEARS)</br><span class="font-bold">(99 = Unknown)</span></label>
+                    <label asp-for="A5D2.HRTYEARS"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.HRTYEARS)</br><span class="font-bold">(999 = Unknown)</span></label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.HRTYEARS"></p>
                         <input asp-for="@Model.A5D2.HRTYEARS" />
@@ -2084,7 +2084,7 @@
                     </div>
                 </div>
                 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A5D2.HRTSTRTAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.HRTSTRTAGE)</br><span class="font-bold">(99 = Unknown)</span></label>
+                    <label asp-for="A5D2.HRTSTRTAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.HRTSTRTAGE)</br><span class="font-bold">(999 = Unknown)</span></label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.HRTSTRTAGE"></p>
                         <input asp-for="@Model.A5D2.HRTSTRTAGE" />
@@ -2092,7 +2092,7 @@
                     </div>
                 </div>
                 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A5D2.HRTENDAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.HRTENDAGE)</br><span class="font-bold">(88 = Still presently using, 99 = Unknown)</span></label>
+                    <label asp-for="A5D2.HRTENDAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.HRTENDAGE)</br><span class="font-bold">(888 = Still presently using, 999 = Unknown)</span></label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.HRTENDAGE"></p>
                         <input asp-for="@Model.A5D2.HRTENDAGE" />
@@ -2112,7 +2112,7 @@
             </div>
             <div class="ml-5">
                 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A5D2.BCPILLSYR"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.BCPILLSYR)</br><span class="font-bold">(99 = Unknown)</span></label>
+                    <label asp-for="A5D2.BCPILLSYR"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.BCPILLSYR)</br><span class="font-bold">(999 = Unknown)</span></label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.BCPILLSYR"></p>
                         <input asp-for="@Model.A5D2.BCPILLSYR" />
@@ -2120,7 +2120,7 @@
                     </div>
                 </div>
                 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A5D2.BCSTARTAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.BCSTARTAGE)</br><span class="font-bold">(99 = Unknown)</span></label>
+                    <label asp-for="A5D2.BCSTARTAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.BCSTARTAGE)</br><span class="font-bold">(999 = Unknown)</span></label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.BCSTARTAGE"></p>
                         <input asp-for="@Model.A5D2.BCSTARTAGE" />
@@ -2128,7 +2128,7 @@
                     </div>
                 </div>
                 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-                    <label asp-for="A5D2.BCENDAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.BCENDAGE)</br><span class="font-bold">(88 = Still presently using, 99 = Unknown)</span></label>
+                    <label asp-for="A5D2.BCENDAGE"><span class="subsubcounter"></span> @Html.DisplayNameFor(m => m.A5D2.BCENDAGE)</br><span class="font-bold">(888 = Still presently using, 999 = Unknown)</span></label>
                     <div class="mt-4 sm:col-span-2 sm:mt-0">
                         <p class="text-sm text-gray-500" asp-description-for="@Model.A5D2.BCENDAGE"></p>
                         <input asp-for="@Model.A5D2.BCENDAGE" />

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
@@ -1422,7 +1422,7 @@ public class A5D2Model : FormPageModel
     public UIRangeToggle MENARCHEBehavior = new UIRangeToggle
     {
         Low = 5,
-        High = 99,
+        High = 999,
         UIBehavior = new UIBehavior
         {
             PropertyAttributes = new List<UIPropertyAttributes>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.9</Version>
+		<Version>6.0.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.9</ReleaseVersion>
+		<ReleaseVersion>6.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.8</Version>
+		<Version>6.0.9</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.8</ReleaseVersion>
+		<ReleaseVersion>6.0.9</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/wwwroot/js/A5D2.js
+++ b/src/UDS.Net.Forms/wwwroot/js/A5D2.js
@@ -27,7 +27,7 @@ $(document).ready(function () {
   }
 
   function MENARCHEBehavior() {
-    if (MENARCHEInput.value >= 5 && MENARCHEInput.value <= 25 | MENARCHEInput.value == 99) {
+    if (MENARCHEInput.value >= 5 && MENARCHEInput.value <= 25 | MENARCHEInput.value == 999) {
       NOMENSAGEInput.disabled = false
     } else {
       NOMENSAGEInput.disabled = true
@@ -37,7 +37,7 @@ $(document).ready(function () {
   }
 
   function ToggleNOMENSAGECheckboxes() {
-    if (NOMENSAGEInput.value >= 10 && NOMENSAGEInput.value <= 70 | NOMENSAGEInput.value == 99) {
+    if (NOMENSAGEInput.value >= 10 && NOMENSAGEInput.value <= 70 | NOMENSAGEInput.value == 999) {
       NOMENSAGECheckboxes.forEach((checkbox) => {
         checkbox.disabled = false
       })

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.9</ReleaseVersion>
+		<ReleaseVersion>6.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.8</ReleaseVersion>
+		<ReleaseVersion>6.0.9</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.8</Version>
+		<Version>6.0.9</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.8</ReleaseVersion>
+		<ReleaseVersion>6.0.9</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.9</Version>
+		<Version>6.0.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.9</ReleaseVersion>
+		<ReleaseVersion>6.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.8</Version>
+		<Version>6.0.9</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.8</ReleaseVersion>
+		<ReleaseVersion>6.0.9</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.9</Version>
+		<Version>6.0.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.9</ReleaseVersion>
+		<ReleaseVersion>6.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.9</ReleaseVersion>
+		<ReleaseVersion>6.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.8</ReleaseVersion>
+		<ReleaseVersion>6.0.9</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
resolves: #286 

## Update age and related validation in A5D2

![image](https://github.com/user-attachments/assets/b201388d-8536-4e18-a962-b18847e01c67)


### Updated valid range list:
- [ ] MENARCHE 5-25, 888, 999
- [ ] NOMENSAGE 10-70, 888, 999
- [ ] HRTYEARS 0-90, 999
- [ ] HRTSTRTAGE 10-110, 999
- [ ] HRTENDAGE 10-110, 888, 999
- [ ] BCPILLSYR 0-50, 999
- [ ] BCSTARTAGE 10-70, 999
- [ ] BCENDAGE 10-70, 888, 999

### Items added in PR
- [ ] Updated regular expressions in a5d2 model for the above items 
- [ ] Updated menarche behaviorh in controller to account for new high range of 999 from 99
- [ ] Updated RequiredIfRange attributes tied to menarche value to 999 from 99
- [ ] Updated label text descriptions to match new range values for the above items in html
- [ ] Updated javascript OR conditional to 999 from 99 for menarcheBehavior and ToggleNomensageCheckboxes methods