### PR TITLE
update the required attribute for PresentSyndromeIndicated

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>6.0.13</ReleaseVersion>
+		<ReleaseVersion>6.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/D1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/D1a.cs
@@ -41,22 +41,6 @@ namespace UDS.Net.Forms.Models.UDS4
         [Display(Name = "Largely preserved functional independence OR functional dependence that is not related to cognitive decline")]
         public bool? MCICRITFUN { get; set; }
 
-        [RequiredIf(nameof(DEMENTED), "0", ErrorMessage = "Please check one or more MCI core clinical criteria.")]
-        [NotMapped]
-        public bool? MCIClinicalCriteriaIndicated
-        {
-            get
-            {
-                if ((MCICRITCLN.HasValue && MCICRITCLN.Value == true) ||
-                    (MCICRITIMP.HasValue && MCICRITIMP.Value == true) ||
-                    (MCICRITFUN.HasValue && MCICRITFUN.Value == true))
-                {
-                    return true;
-                }
-                else return null;
-            }
-        }
-
         [NotMapped]
         [RequiredIf(nameof(DEMENTED), "0", ErrorMessage = "If all three criteria in question 4 are checked, choose 1=MCI. If less than 3 criteria are met, choose 0=No.")]
         public bool? MCICriteriaValidation
@@ -71,15 +55,18 @@ namespace UDS.Net.Forms.Models.UDS4
                     criteriaCount += MCICRITIMP.HasValue && MCICRITIMP.Value == true ? 1 : 0;
                     criteriaCount += MCICRITFUN.HasValue && MCICRITFUN.Value == true ? 1 : 0;
 
-                    if(criteriaCount == 3)
+                    if (criteriaCount == 3)
                     {
                         return MCI.Value == 1 ? true : null;
+                    } 
+                    
+                    if(criteriaCount == 0)
+                    {
+                        return MCI.Value == 0 ? true : null;
                     }
-
-                    return MCI.Value == 0 ? true : null;
                 }
 
-                return null;
+                return true;
             }
         }
 
@@ -245,6 +232,40 @@ namespace UDS.Net.Forms.Models.UDS4
         [Display(Name = "Is there a predominant clinical syndrome?")]
         public int? PREDOMSYN { get; set; }
 
+        [RequiredIf(nameof(PREDOMSYN), "1", ErrorMessage = "If a predominant clinical syndrome was present in question 8, a dementia syndrome must be marked as present")]
+        [NotMapped]
+        public bool? PREDOMSYNSyndromePresent
+        {
+            get
+            {
+                if (PREDOMSYN == 1)
+                {
+                    //one of the 8 sub qustions must be present
+                    var PREDOMSYNSyndromeCount = 0;
+
+                    if (AMNDEM.HasValue && AMNDEM.Value == true) PREDOMSYNSyndromeCount++;
+                    if (DYEXECSYN.HasValue && DYEXECSYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (PCA.HasValue && PCA.Value == true) PREDOMSYNSyndromeCount++;
+                    if (PPASYN.HasValue && PPASYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (FTDSYN.HasValue && FTDSYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (LBDSYN.HasValue && LBDSYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (NAMNDEM.HasValue && NAMNDEM.Value == true) PREDOMSYNSyndromeCount++;
+                    if (PSPSYN.HasValue && PSPSYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (CTESYN.HasValue && CTESYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (CBSSYN.HasValue && CBSSYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (MSASYN.HasValue && MSASYN.Value == true) PREDOMSYNSyndromeCount++;
+                    if (OTHSYN.HasValue && OTHSYN.Value == true) PREDOMSYNSyndromeCount++;
+
+                    if (PREDOMSYNSyndromeCount == 0)
+                    {
+                        return null;
+                    }
+                }
+
+                return true;
+            }
+        }
+
         [Display(Name = "Amnestic predominant syndrome")]
         public bool? AMNDEM { get; set; }
 
@@ -311,7 +332,7 @@ namespace UDS.Net.Forms.Models.UDS4
         [Display(Name = "Biomarkers (MRI, PET, CSF, plasma)")]
         public bool? SYNINFBIOM { get; set; }
 
-        [RequiredIf(nameof(PREDOMSYN), "1", ErrorMessage = "Please select one or more source as Yes.")]
+        [RequiredIf(nameof(PREDOMSYN), "1", ErrorMessage = "If a predominant clinical syndrome was present in question 8, a source must be selected.")]
         [NotMapped]
         public bool? SourceIndicated
         {
@@ -550,7 +571,7 @@ namespace UDS.Net.Forms.Models.UDS4
         [RequiredIf(nameof(COGOTH3), "True", ErrorMessage = "Please indicate")]
         public string? COGOTH3X { get; set; }
 
-        [RequiredIf(nameof(PREDOMSYN), "0", ErrorMessage = "Select one or more syndrome(s) as Present.")]
+        [RequiredIf(nameof(PREDOMSYN), "0", ErrorMessage = "If a predominant clinical syndrome was not present in question 8, a condition must be selected.")]
         [NotMapped]
         public bool? PresentSyndromeIndicated
         {
@@ -649,14 +670,12 @@ namespace UDS.Net.Forms.Models.UDS4
                 {
                     counter++;
                 }
-                if (NORMCOG == 0 && counter >= 1)
+
+                if (counter >= 1)
                 {
                     return true;
                 }
-                else if (NORMCOG == 1 && counter == 0)
-                {
-                    return true;
-                }
+                
                 return null;
             }
         }

--- a/src/UDS.Net.Forms/Models/UDS4/D1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/D1a.cs
@@ -57,6 +57,33 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
+        [NotMapped]
+        [RequiredIf(nameof(DEMENTED), "0", ErrorMessage = "If all three criteria in question 4 are checked, choose 1=MCI. If less than 3 criteria are met, choose 0=No.")]
+        public bool? MCICriteriaValidation
+        {
+            get
+            {
+                if(MCI.HasValue)
+                {
+                    var criteriaCount = 0;
+
+                    criteriaCount += MCICRITCLN.HasValue && MCICRITCLN.Value == true ? 1 : 0;
+                    criteriaCount += MCICRITIMP.HasValue && MCICRITIMP.Value == true ? 1 : 0;
+                    criteriaCount += MCICRITFUN.HasValue && MCICRITFUN.Value == true ? 1 : 0;
+
+                    if(criteriaCount == 3)
+                    {
+                        return MCI.Value == 1 ? true : null;
+                    }
+
+                    return MCI.Value == 0 ? true : null;
+                }
+
+                return null;
+            }
+        }
+
+
         [RequiredIf(nameof(DEMENTED), "0", ErrorMessage = "Please specify.")]
         [Display(Name = "Does the participant meet all three of the above criteria for MCI (amnestic or non-amnestic)?")]
         public int? MCI { get; set; }
@@ -78,20 +105,67 @@ namespace UDS.Net.Forms.Models.UDS4
         [RequiredIf(nameof(IMPNOMCIO), "True", ErrorMessage = "Please specify.")]
         public string? IMPNOMCIOX { get; set; }
 
-        [RequiredIf(nameof(MCI), "0", ErrorMessage = "Please  check all applicable criteria for cognitively impaired, not MCI/dementia in")]
+        //If any of the criteria in Q5 are met, or if only some of the MCI criteria from Q4 are met, choose 1=Yes
+        // this looks like q5 criteria CAN be unchecked? 
+
+        //[RequiredIf(nameof(MCI), "0", ErrorMessage = "Please  check all applicable criteria for cognitively impaired, not MCI/dementia in")]
+        //[NotMapped]
+        //public bool? CognitivelyImpairedIndicated
+        //{
+        //    get
+        //    {
+        //        if ((IMPNOMCIFU.HasValue && IMPNOMCIFU.Value == true) ||
+        //            (IMPNOMCICG.HasValue && IMPNOMCICG.Value == true) ||
+        //            (IMPNOMCLCD.HasValue && IMPNOMCLCD.Value == true) ||
+        //            (IMPNOMCIO.HasValue && IMPNOMCIO.Value == true))
+        //        {
+        //            return true;
+        //        }
+        //        else return null;
+        //    }
+        //}
+
+        [RequiredIf(nameof(MCI), "0", ErrorMessage = "If any of the criteria in Q5 are met, or if only some of the MCI criteria from Q4 are met, choose 1=Yes for Q5b. Note, if only the third MCI criteria is met in Q4, select 0=No for Q5b.")]
         [NotMapped]
-        public bool? CognitivelyImpairedIndicated
+        public bool? IMPNOMCICriteriaValidation
         {
             get
             {
-                if ((IMPNOMCIFU.HasValue && IMPNOMCIFU.Value == true) ||
-                    (IMPNOMCICG.HasValue && IMPNOMCICG.Value == true) ||
-                    (IMPNOMCLCD.HasValue && IMPNOMCLCD.Value == true) ||
-                    (IMPNOMCIO.HasValue && IMPNOMCIO.Value == true))
+                if (IMPNOMCI.HasValue)
                 {
-                    return true;
+                    var IMPNOMCICriteriaCount = 0;
+
+                    IMPNOMCICriteriaCount += IMPNOMCIFU.HasValue && IMPNOMCIFU.Value == true ? 1 : 0;
+                    IMPNOMCICriteriaCount += IMPNOMCICG.HasValue && IMPNOMCICG.Value == true ? 1 : 0;
+                    IMPNOMCICriteriaCount += IMPNOMCLCD.HasValue && IMPNOMCLCD.Value == true ? 1 : 0;
+                    IMPNOMCICriteriaCount += IMPNOMCIO.HasValue && IMPNOMCIO.Value == true ? 1 : 0;
+
+                    if (IMPNOMCICriteriaCount > 0)
+                    {
+                        return IMPNOMCI.Value == 1 ? true : null;
+                    }
+
+                    if (IMPNOMCICriteriaCount <= 0)
+                    {
+                        var MCICriteriaCount = 0;
+
+                        MCICriteriaCount += MCICRITCLN.HasValue && MCICRITCLN.Value == true ? 1 : 0;
+                        MCICriteriaCount += MCICRITIMP.HasValue && MCICRITIMP.Value == true ? 1 : 0;
+                        MCICriteriaCount += MCICRITFUN.HasValue && MCICRITFUN.Value == true ? 1 : 0;
+
+                        if (MCICriteriaCount == 1 && MCICRITFUN.HasValue && MCICRITFUN.Value == true)
+                        {
+                            return IMPNOMCI.Value == 0 ? true : null;
+                        }
+
+                        if (MCICriteriaCount > 0)
+                        {
+                            return IMPNOMCI.Value == 1 ? true : null;
+                        }
+                    }
                 }
-                else return null;
+
+                return null;
             }
         }
 

--- a/src/UDS.Net.Forms/Models/UDS4/D1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/D1a.cs
@@ -60,7 +60,7 @@ namespace UDS.Net.Forms.Models.UDS4
                         return MCI.Value == 1 ? true : null;
                     }
 
-                    if (criteriaCount == 0)
+                    if (criteriaCount < 3)
                     {
                         return MCI.Value == 0 ? true : null;
                     }

--- a/src/UDS.Net.Forms/Models/UDS4/D1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/D1a.cs
@@ -47,7 +47,7 @@ namespace UDS.Net.Forms.Models.UDS4
         {
             get
             {
-                if(MCI.HasValue)
+                if (MCI.HasValue)
                 {
                     var criteriaCount = 0;
 
@@ -58,9 +58,9 @@ namespace UDS.Net.Forms.Models.UDS4
                     if (criteriaCount == 3)
                     {
                         return MCI.Value == 1 ? true : null;
-                    } 
-                    
-                    if(criteriaCount == 0)
+                    }
+
+                    if (criteriaCount == 0)
                     {
                         return MCI.Value == 0 ? true : null;
                     }
@@ -91,26 +91,6 @@ namespace UDS.Net.Forms.Models.UDS4
         [MaxLength(60)]
         [RequiredIf(nameof(IMPNOMCIO), "True", ErrorMessage = "Please specify.")]
         public string? IMPNOMCIOX { get; set; }
-
-        //If any of the criteria in Q5 are met, or if only some of the MCI criteria from Q4 are met, choose 1=Yes
-        // this looks like q5 criteria CAN be unchecked? 
-
-        //[RequiredIf(nameof(MCI), "0", ErrorMessage = "Please  check all applicable criteria for cognitively impaired, not MCI/dementia in")]
-        //[NotMapped]
-        //public bool? CognitivelyImpairedIndicated
-        //{
-        //    get
-        //    {
-        //        if ((IMPNOMCIFU.HasValue && IMPNOMCIFU.Value == true) ||
-        //            (IMPNOMCICG.HasValue && IMPNOMCICG.Value == true) ||
-        //            (IMPNOMCLCD.HasValue && IMPNOMCLCD.Value == true) ||
-        //            (IMPNOMCIO.HasValue && IMPNOMCIO.Value == true))
-        //        {
-        //            return true;
-        //        }
-        //        else return null;
-        //    }
-        //}
 
         [RequiredIf(nameof(MCI), "0", ErrorMessage = "If any of the criteria in Q5 are met, or if only some of the MCI criteria from Q4 are met, choose 1=Yes for Q5b. Note, if only the third MCI criteria is met in Q4, select 0=No for Q5b.")]
         [NotMapped]
@@ -675,7 +655,7 @@ namespace UDS.Net.Forms.Models.UDS4
                 {
                     return true;
                 }
-                
+
                 return null;
             }
         }

--- a/src/UDS.Net.Forms/Models/UDS4/D1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/D1a.cs
@@ -476,7 +476,7 @@ namespace UDS.Net.Forms.Models.UDS4
         [RequiredIf(nameof(COGOTH3), "True", ErrorMessage = "Please indicate")]
         public string? COGOTH3X { get; set; }
 
-        [RequiredOnFinalized(ErrorMessage = "Select one or more syndrome(s) as Present.")]
+        [RequiredIf(nameof(PREDOMSYN), "0", ErrorMessage = "Select one or more syndrome(s) as Present.")]
         [NotMapped]
         public bool? PresentSyndromeIndicated
         {

--- a/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
@@ -193,7 +193,6 @@
             <span class="counter"></span>Check all applicable criteria for cognitively impaired, not MCI/dementia in Q5, using any relevant data. Any conditions
             contributing to impairment (e.g., substance abuse or medications) should be identified in Section 3.
         </label><br />
-        @* <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.CognitivelyImpairedIndicated"></span> *@
     </div>
     <div class="mt-4 sm:col-span-2 sm:mt-0">
         <fieldset class="subsubcounterreset">

--- a/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
@@ -122,7 +122,6 @@
     <div class="ml-2 sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
         <div>
             <label class="text-base font-semibold text-gray-900"><span class="counter subcounterreset"></span>Check all criteria that apply in Q4.</label><br />
-            <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.MCIClinicalCriteriaIndicated"></span>
         </div>
         <div class="mt-4 sm:col-span-2 sm:mt-0">
             <fieldset class="subsubcounterreset">
@@ -580,6 +579,7 @@
     </div>
 </div>
 <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+    <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.PREDOMSYNSyndromePresent"></span>
     <table class="ml-2 table-auto min-w-full divide-y divide-gray-300">
         <thead>
             <tr class="odd:bg-white even:bg-gray-50 border-b">
@@ -925,7 +925,9 @@
                         <span class="counter"></span>Indicate the source(s) of information used to assign the clinical syndrome:
                         Select one or more as Yes; all others will default to No in the NACC database
                     </label>
-                    <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.SourceIndicated"></span>
+                    <div>
+                        <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.SourceIndicated"></span>
+                    </div>
                 </td>
             </tr>
             <tr class="odd:bg-white even:bg-gray-50 border-b">

--- a/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
@@ -166,6 +166,7 @@
         <p class="text-sm text-gray-500" asp-description-for="@Model.D1a.MCI"></p>
         <radio-button-group id="@Html.IdFor(m => m.D1a.MCI)" for="@Model.D1a.MCI" items="Model.MCIListItems" ui-behaviors="Model.MCIUIBehavior"></radio-button-group>
         <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.MCI"></span>
+        <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.MCICriteriaValidation"></span>
     </div>
     <p class="italic text-gray-500">If all three criteria are checked, choose <strong>1=MCI</strong> for Q4b. If less than 3 criteria are met, choose <strong>0=No</strong> for Q4b.</p>
 </div>
@@ -193,7 +194,7 @@
             <span class="counter"></span>Check all applicable criteria for cognitively impaired, not MCI/dementia in Q5, using any relevant data. Any conditions
             contributing to impairment (e.g., substance abuse or medications) should be identified in Section 3.
         </label><br />
-        <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.CognitivelyImpairedIndicated"></span>
+        @* <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.CognitivelyImpairedIndicated"></span> *@
     </div>
     <div class="mt-4 sm:col-span-2 sm:mt-0">
         <fieldset class="subsubcounterreset">
@@ -257,6 +258,7 @@
         <p class="text-sm text-gray-500" asp-description-for="@Model.D1a.IMPNOMCI"></p>
         <radio-button-group id="@Html.IdFor(m => m.D1a.IMPNOMCI)" for="@Model.D1a.IMPNOMCI" items="Model.IMPNOMCIListItems"></radio-button-group>
         <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.IMPNOMCI"></span>
+        <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.IMPNOMCICriteriaValidation"></span>
     </div>
     <span class="text-gray-500 italic">
         If any of the criteria in Q5 are met, or if only some of the MCI criteria from Q4 are met, choose 1=Yes for Q5b. Note, if <strong><u>only</u></strong> the third

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.13</Version>
+		<Version>6.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.13</ReleaseVersion>
+		<ReleaseVersion>6.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>6.0.13</ReleaseVersion>
+		<ReleaseVersion>6.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.13</Version>
+		<Version>6.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.13</ReleaseVersion>
+		<ReleaseVersion>6.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.13</Version>
+		<Version>6.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.13</ReleaseVersion>
+		<ReleaseVersion>6.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>6.0.13</ReleaseVersion>
+		<ReleaseVersion>6.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves: #282 

## PREDOMSYN requirement
This PR allows section 3 to not be answered if question 8 (PREDOMSYN) is 1. This, in turn, will make section 3 values required when question 8 is 0


- [x] If PREDOMSYN = 1 then a selection in section 3 should not be required
- [x] a selection in section 3 is required when PREDOMSYN = 0

## This PR has undergone some additional scope changes 
In light of some rule clarification, we adjusted some additional validation on this form **[Copied from comment below]**

#### Question 4
![image](https://github.com/user-attachments/assets/10576404-86f6-4666-87d3-bafbc294bd1b)
- [x] if all checkboxes are checked question 4b (MCI) must be equal to 1
- [x] if not all check boxes are checked question 4b (MCI) must be equal to 0
- [x] if no checkboxes are selected MCI must be 0

##### Question 5
![image](https://github.com/user-attachments/assets/00c5638b-4981-40cc-b7e7-3a8b703e9ca4)
- [x] if any of the checkboxes from question 4 are checked **With the exception of JUST the third checbox** OR if any of the checkboxes from question 5 are checked, then question 5b (IMPNOMCI) should be 1 - Yes
- [x] if **ONLY** the third checkbox in question 4 is checked and no options in question 5 are checked, then question 5b (IMPNOMCI) should be 0 - No
- [x] When PREDOMSYN (question 8) is 1 at least 1 sub question from 8a - 8l should be marked as "present" AND at least one checkbox from question 9 should be checked
- [x] When PREDOMSYN (question 8) is 0 at least one question from 10 - 32 should be selected as present



