### PR TITLE
Added validation

### DIFF
--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -47,7 +47,7 @@ namespace UDS.Net.Forms.Models.UDS4
 
         [Display(Name = "Total Raw Score - Uncorrected", Description = "(0-22,88)")]
         [RegularExpression("^(\\d|1\\d|2[0-2]|88)$", ErrorMessage = "Allowed values are 0-22 or 88 = not administered.")]
-        [RequiredIfTelephoneVisitAttribute(nameof(MOCACOMP), "Finalized", ErrorMessage = "MOCBTOTS field required")]
+        [RequiredIfTelephoneVisit(nameof(MOCACOMP), "1", ErrorMessage = "Response required")]
 
         public int? MOCBTOTS { get; set; }
         [Display(Name = "Visuospatial/executive — Trails", Description = "(0-1, 95-98)")]

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -790,7 +790,7 @@ namespace UDS.Net.Forms.Models.UDS4
                     {
                         if (MOCBTOTS.Value != 88)
                         {
-                            yield return new ValidationResult("If 1g-1l, 1n-1t, or 1w-1bb were not administered then MOCBTOTS must be 88.", new[] { nameof(MOCATOTS) });
+                            yield return new ValidationResult("If 1e–1k or 1n–1s were not administered then MOCBTOTS must be 88.", new[] { nameof(MOCATOTS) });
                         }
                     }
                 }

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -47,7 +47,7 @@ namespace UDS.Net.Forms.Models.UDS4
 
         [Display(Name = "Total Raw Score - Uncorrected", Description = "(0-22,88)")]
         [RegularExpression("^(\\d|1\\d|2[0-2]|88)$", ErrorMessage = "Allowed values are 0-22 or 88 = not administered.")]
-        [RequiredIfTelephoneVisitAttribute(nameof(RMMODE), "Finalized")]
+        [RequiredIfTelephoneVisitAttribute(nameof(MOCACOMP), "Finalized", ErrorMessage = "MOCBTOTS field required")]
 
         public int? MOCBTOTS { get; set; }
         [Display(Name = "Visuospatial/executive — Trails", Description = "(0-1, 95-98)")]

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -48,8 +48,8 @@ namespace UDS.Net.Forms.Models.UDS4
         [Display(Name = "Total Raw Score - Uncorrected", Description = "(0-22,88)")]
         [RegularExpression("^(\\d|1\\d|2[0-2]|88)$", ErrorMessage = "Allowed values are 0-22 or 88 = not administered.")]
         [RequiredIfTelephoneVisit(nameof(MOCACOMP), "1", ErrorMessage = "Response required")]
-
         public int? MOCBTOTS { get; set; }
+
         [Display(Name = "Visuospatial/executive — Trails", Description = "(0-1, 95-98)")]
         [RegularExpression("^([0-1]|9[5-8])$", ErrorMessage = "Allowed values are 0-1 or 95-98.")]
         [RequiredIfInPersonVisit(nameof(MOCACOMP), "1", ErrorMessage = "Response required")]

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -758,16 +758,43 @@ namespace UDS.Net.Forms.Models.UDS4
                 // 1z MOCAORDY
                 // 1aa MOCAORPL
                 // 1bb MOCAORCT
-                if (MOCATOTS.HasValue &&
-                    ((MOCATRAI.HasValue && MOCATRAI.Value >= 95) || (MOCACUBE.HasValue && MOCACUBE.Value >= 95) || (MOCACLOC.HasValue && MOCACLOC.Value >= 95) || (MOCACLON.HasValue && MOCACLON.Value >= 95) || (MOCACLOH.HasValue && MOCACLOH.Value >= 95) || (MOCANAMI.HasValue && MOCANAMI.Value >= 95)
-                    || (MOCADIGI.HasValue && MOCADIGI.Value >= 95) || (MOCALETT.HasValue && MOCALETT.Value >= 95) || (MOCASER7.HasValue && MOCASER7.Value >= 95) || (MOCAREPE.HasValue && MOCAREPE.Value >= 95) || (MOCAFLUE.HasValue && MOCAFLUE.Value >= 95) || (MOCAABST.HasValue && MOCAABST.Value >= 95) || (MOCARECN.HasValue && MOCARECN.Value >= 95)
-                    || (MOCAORDT.HasValue && MOCAORDT.Value >= 95) || (MOCAORMO.HasValue && MOCAORMO.Value >= 95) || (MOCAORYR.HasValue && MOCAORYR.Value >= 95) || (MOCAORDY.HasValue && MOCAORDY.Value >= 95) || (MOCAORPL.HasValue && MOCAORPL.Value >= 95) || (MOCAORCT.HasValue && MOCAORCT.Value >= 95)))
+                if (MODE == FormMode.InPerson || (MODE == FormMode.Remote && RMMODE == RemoteModality.Video))
                 {
-                    if (MOCATOTS.Value != 88)
+                    if (MOCATOTS.HasValue &&
+                        ((MOCATRAI.HasValue && MOCATRAI.Value >= 95) || (MOCACUBE.HasValue && MOCACUBE.Value >= 95) || (MOCACLOC.HasValue && MOCACLOC.Value >= 95) || (MOCACLON.HasValue && MOCACLON.Value >= 95) || (MOCACLOH.HasValue && MOCACLOH.Value >= 95) || (MOCANAMI.HasValue && MOCANAMI.Value >= 95)
+                        || (MOCADIGI.HasValue && MOCADIGI.Value >= 95) || (MOCALETT.HasValue && MOCALETT.Value >= 95) || (MOCASER7.HasValue && MOCASER7.Value >= 95) || (MOCAREPE.HasValue && MOCAREPE.Value >= 95) || (MOCAFLUE.HasValue && MOCAFLUE.Value >= 95) || (MOCAABST.HasValue && MOCAABST.Value >= 95) || (MOCARECN.HasValue && MOCARECN.Value >= 95)
+                        || (MOCAORDT.HasValue && MOCAORDT.Value >= 95) || (MOCAORMO.HasValue && MOCAORMO.Value >= 95) || (MOCAORYR.HasValue && MOCAORYR.Value >= 95) || (MOCAORDY.HasValue && MOCAORDY.Value >= 95) || (MOCAORPL.HasValue && MOCAORPL.Value >= 95) || (MOCAORCT.HasValue && MOCAORCT.Value >= 95)))
                     {
-                        yield return new ValidationResult("If 1g-1l, 1n-1t, or 1w-1bb were not administered then MOCATOTS must be 88.", new[] { nameof(MOCATOTS) });
+                        if (MOCATOTS.Value != 88)
+                        {
+                            yield return new ValidationResult("If 1g-1l, 1n-1t, or 1w-1bb were not administered then MOCATOTS must be 88.", new[] { nameof(MOCATOTS) });
+                        }
                     }
                 }
+                else if ((MODE == FormMode.Remote && RMMODE == RemoteModality.Telephone))
+                {
+                    if (MOCBTOTS.HasValue &&
+                        ((MOCADIGI.HasValue && MOCADIGI.Value >= 95 && MOCADIGI.Value <= 98) ||
+                        (MOCALETT.HasValue && MOCALETT.Value >= 95 && MOCALETT.Value <= 98) ||
+                        (MOCASER7.HasValue && MOCASER7.Value >= 95 && MOCASER7.Value <= 98) ||
+                        (MOCAREPE.HasValue && MOCAREPE.Value >= 95 && MOCAREPE.Value <= 98) ||
+                        (MOCAFLUE.HasValue && MOCAFLUE.Value >= 95 && MOCAFLUE.Value <= 98) ||
+                        (MOCAABST.HasValue && MOCAABST.Value >= 95 && MOCAABST.Value <= 98) ||
+                        (MOCARECN.HasValue && MOCARECN.Value >= 95 && MOCARECN.Value <= 98) ||
+                        (MOCAORDT.HasValue && MOCAORDT.Value >= 95 && MOCAORDT.Value <= 98) ||
+                        (MOCAORMO.HasValue && MOCAORMO.Value >= 95 && MOCAORMO.Value <= 98) ||
+                        (MOCAORYR.HasValue && MOCAORYR.Value >= 95 && MOCAORYR.Value <= 98) ||
+                        (MOCAORDY.HasValue && MOCAORDY.Value >= 95 && MOCAORDY.Value <= 98) ||
+                        (MOCAORPL.HasValue && MOCAORPL.Value >= 95 && MOCAORPL.Value <= 98) ||
+                        (MOCAORCT.HasValue && MOCAORCT.Value >= 95 && MOCAORCT.Value <= 98)))
+                    {
+                        if (MOCBTOTS.Value != 88)
+                        {
+                            yield return new ValidationResult("If 1g-1l, 1n-1t, or 1w-1bb were not administered then MOCBTOTS must be 88.", new[] { nameof(MOCATOTS) });
+                        }
+                    }
+                }
+
 
                 if (Status == FormStatus.Finalized)
                 {

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -47,8 +47,9 @@ namespace UDS.Net.Forms.Models.UDS4
 
         [Display(Name = "Total Raw Score - Uncorrected", Description = "(0-22,88)")]
         [RegularExpression("^(\\d|1\\d|2[0-2]|88)$", ErrorMessage = "Allowed values are 0-22 or 88 = not administered.")]
-        public int? MOCBTOTS { get; set; }
+        [RequiredIfTelephoneVisitAttribute(nameof(RMMODE), "Finalized")]
 
+        public int? MOCBTOTS { get; set; }
         [Display(Name = "Visuospatial/executive — Trails", Description = "(0-1, 95-98)")]
         [RegularExpression("^([0-1]|9[5-8])$", ErrorMessage = "Allowed values are 0-1 or 95-98.")]
         [RequiredIfInPersonVisit(nameof(MOCACOMP), "1", ErrorMessage = "Response required")]
@@ -790,7 +791,7 @@ namespace UDS.Net.Forms.Models.UDS4
                     {
                         if (MOCBTOTS.Value != 88)
                         {
-                            yield return new ValidationResult("If 1e–1k or 1n–1s were not administered then MOCBTOTS must be 88.", new[] { nameof(MOCATOTS) });
+                            yield return new ValidationResult("If 1e–1k or 1n–1s were not administered then MOCBTOTS must be 88.", new[] { nameof(MOCBTOTS) });
                         }
                     }
                 }

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>6.0.11</Version>
+		<Version>6.0.12</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.11</ReleaseVersion>
+		<ReleaseVersion>6.0.12</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>6.0.11</Version>
+		<Version>6.0.12</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.11</ReleaseVersion>
+		<ReleaseVersion>6.0.12</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="4.5.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>6.0.11</Version>
+		<Version>6.0.12</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>6.0.11</ReleaseVersion>
+		<ReleaseVersion>6.0.12</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>


### PR DESCRIPTION
Fixes #233 

Added validation for `MOCBTOTS`

The condition is that questions `1e–1k` and `1n–1s` must be between 95 and 98, and `MOCBTOTS != 88`. 
An error message will be shown: "`If 1e–1k or 1n–1s were not administered, then MOCBTOTS must be 88`".