### PR TITLE
 Remove TRSPLONGER from A1a

### DIFF
--- a/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
@@ -514,7 +514,6 @@ namespace UDS.Net.Forms.Extensions
                 TRSPACCESS = fields.TRSPACCESS,
                 TRANSPROB = fields.TRANSPROB,
                 TRANSWORRY = fields.TRANSWORRY,
-                TRSPLONGER = fields.TRSPLONGER,
                 TRSPMED = fields.TRSPMED,
                 INCOMEYR = fields.INCOMEYR,
                 FINSATIS = fields.FINSATIS,

--- a/src/UDS.Net.Forms/Extensions/ViewModelToDomainMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/ViewModelToDomainMapper.cs
@@ -269,7 +269,6 @@ namespace UDS.Net.Forms.Extensions
                 TRSPACCESS = vm.TRSPACCESS,
                 TRANSPROB = vm.TRANSPROB,
                 TRANSWORRY = vm.TRANSWORRY,
-                TRSPLONGER = vm.TRSPLONGER,
                 TRSPMED = vm.TRSPMED,
                 INCOMEYR = vm.INCOMEYR,
                 FINSATIS = vm.FINSATIS,

--- a/src/UDS.Net.Forms/Models/UDS4/A1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1a.cs
@@ -27,11 +27,6 @@ namespace UDS.Net.Forms.Models.UDS4
         [RequiredOnFinalized(ErrorMessage = "Response required")]
         public int? TRANSWORRY { get; set; }
 
-        [Display(Name = "In the past 30 days, how often did it take you longer to get somewhere than it would have taken you if you had different transportation?")]
-        [RegularExpression("^([1-3]|8)$", ErrorMessage = "Valid range is 1-3 or 8")]
-        [RequiredOnFinalized(ErrorMessage = "Response required")]
-        public int? TRSPLONGER { get; set; }
-
         [Display(Name = "In the past 30 days, how often has a lack of transportation kept you from medical appointments or from doing things needed for daily living?")]
         [RegularExpression("^([1-3]|8)$", ErrorMessage = "Valid range is 1-3 or 8")]
         [RequiredOnFinalized(ErrorMessage = "Response required")]

--- a/src/UDS.Net.Forms/Pages/UDS4/A1a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1a.cshtml
@@ -56,16 +56,6 @@
         </div>
     </div>
     <div class="@rowCSS">
-        <label asp-for="A1a.TRSPLONGER"><span class="counter"></span> @Html.DisplayNameFor(model => model.A1a.TRSPLONGER)</label>
-        <div class="mt-4 sm:col-span-2 sm:mt-0">
-            <div class="max-w-lg">
-                <p class="text-sm text-gray-500" asp-description-for="@Model.A1a.TRSPLONGER"></p>
-                <radio-button-group id="A1_TRSPLONGER" for="A1a.TRSPLONGER" items="Model.OftenToNeverItems"></radio-button-group>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.A1a.TRSPLONGER"></span>
-            </div>
-        </div>
-    </div>
-    <div class="@rowCSS">
         <label asp-for="A1a.TRSPMED"><span class="counter"></span> @Html.DisplayNameFor(model => model.A1a.TRSPMED)</label>
         <div class="mt-4 sm:col-span-2 sm:mt-0">
             <div class="max-w-lg">

--- a/src/UDS.Net.Services/DomainModels/Forms/A1aFormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A1aFormFields.cs
@@ -11,7 +11,6 @@ namespace UDS.Net.Services.DomainModels.Forms
         public int? TRSPACCESS { get; set; }
         public int? TRANSPROB { get; set; }
         public int? TRANSWORRY { get; set; }
-        public int? TRSPLONGER { get; set; }
         public int? TRSPMED { get; set; }
         public int? INCOMEYR { get; set; }
         public int? FINSATIS { get; set; }
@@ -113,7 +112,6 @@ namespace UDS.Net.Services.DomainModels.Forms
                 TRSPACCESS = a1aDto.TRSPACCESS;
                 TRANSPROB = a1aDto.TRANSPROB;
                 TRANSWORRY = a1aDto.TRANSWORRY;
-                TRSPLONGER = a1aDto.TRSPLONGER;
                 TRSPMED = a1aDto.TRSPMED;
                 INCOMEYR = a1aDto.INCOMEYR;
                 FINSATIS = a1aDto.FINSATIS;

--- a/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
@@ -410,7 +410,6 @@ namespace UDS.Net.Services.Extensions
                 TRSPACCESS = fields.TRSPACCESS,
                 TRANSPROB = fields.TRANSPROB,
                 TRANSWORRY = fields.TRANSWORRY,
-                TRSPLONGER = fields.TRSPLONGER,
                 TRSPMED = fields.TRSPMED,
                 INCOMEYR = fields.INCOMEYR,
                 FINSATIS = fields.FINSATIS,


### PR DESCRIPTION
Fix: #314 

This PR removes the TRSPLONGER  property so that the A1a form is up to date with the NACC spec