### PR TITLE
Support some of finalization

### DIFF
--- a/src/UDS.Net.Forms.Tests/Services/VisitService.cs
+++ b/src/UDS.Net.Forms.Tests/Services/VisitService.cs
@@ -103,6 +103,11 @@ namespace UDS.Net.Forms.Tests.Services
         {
             throw new NotImplementedException();
         }
+
+        public Task<Visit> PatchStatus(string username, Visit entity)
+        {
+            throw new NotImplementedException();
+        }
     }
 }
 

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>8.0.2</ReleaseVersion>
+		<ReleaseVersion>9.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
@@ -89,7 +89,8 @@ namespace UDS.Net.Forms.Extensions
                 ModifiedBy = visit.ModifiedBy,
                 DeletedBy = visit.DeletedBy,
                 IsDeleted = visit.IsDeleted,
-                CanBeFinalized = visit.IsFinalizable,
+                CanBeFinalized = visit.TryUpdateStatus(Services.Enums.PacketStatus.Finalized),
+                CanBeEdited = visit.TryUpdateStatus(Services.Enums.PacketStatus.Pending),
                 Forms = visit.Forms.ToVM(),
                 TotalUnresolvedErrorCount = visit.UnresolvedErrorCount
             };
@@ -133,7 +134,8 @@ namespace UDS.Net.Forms.Extensions
                 ModifiedBy = packet.ModifiedBy,
                 DeletedBy = packet.DeletedBy,
                 IsDeleted = packet.IsDeleted,
-                CanBeFinalized = packet.IsFinalizable,
+                CanBeFinalized = packet.TryUpdateStatus(Services.Enums.PacketStatus.Finalized),
+                CanBeEdited = packet.TryUpdateStatus(Services.Enums.PacketStatus.Pending),
                 Forms = packet.Forms.ToVM(),
                 PacketSubmissions = packet.Submissions.ToVM()
             };

--- a/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
+++ b/src/UDS.Net.Forms/Models/PageModels/FormPageModel.cs
@@ -113,10 +113,21 @@ namespace UDS.Net.Forms.Models.PageModels
                 }
             }
 
+            if (!visit.TryUpdateStatus(PacketStatus.Pending))
+            {
+                ModelState.AddModelError($"{BaseForm.GetType().Name}.Status", $"Form cannot be modified because packet is in {visit.Status.ToString()} status.");
+            }
+
             if (ModelState.IsValid)
             {
                 try
                 {
+                    if (visit.Status != PacketStatus.Pending)
+                    {
+                        visit.UpdateStatus(PacketStatus.Pending);
+                        await _visitService.PatchStatus(User.Identity.Name, visit);
+                    }
+
                     await _visitService.UpdateForm(User.Identity.IsAuthenticated ? User.Identity.Name : "username", visit, _formKind);
 
                     if (!String.IsNullOrWhiteSpace(goNext) && !String.IsNullOrWhiteSpace(BaseForm.NextFormKind))

--- a/src/UDS.Net.Forms/Models/VisitModel.cs
+++ b/src/UDS.Net.Forms/Models/VisitModel.cs
@@ -36,6 +36,7 @@ namespace UDS.Net.Forms.Models
         public PacketStatus Status { get; set; }
 
         public bool CanBeFinalized { get; set; } = false;
+        public bool CanBeEdited { get; set; } = true;
 
         public int? TotalUnresolvedErrorCount { get; set; }
 

--- a/src/UDS.Net.Forms/Pages/Lookup/DrugCode.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/Lookup/DrugCode.cshtml.cs
@@ -29,7 +29,7 @@ namespace UDS.Net.Forms.Pages.Lookup
             if (visitId == null || visitId == 0)
                 return NotFound();
 
-            var visit = await _visitService.GetByIdWithForm("", visitId.Value, _formKind);
+            var visit = await _visitService.GetByIdWithForm(User.Identity.Name, visitId.Value, _formKind);
 
             if (visit == null)
                 return NotFound();
@@ -55,7 +55,7 @@ namespace UDS.Net.Forms.Pages.Lookup
             if (visitId == null || visitId == 0)
                 return NotFound();
 
-            var entity = await _visitService.GetByIdWithForm("", visitId.Value, _formKind);
+            var entity = await _visitService.GetByIdWithForm(User.Identity.Name, visitId.Value, _formKind);
 
             if (entity == null)
                 return NotFound();

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Create.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Create.cshtml.cs
@@ -41,12 +41,12 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
             if (packetId == null || packetId == 0)
                 return NotFound();
 
-            var packet = await _packetService.GetById("", packetId.Value);
+            var packet = await _packetService.GetById(User.Identity.Name, packetId.Value);
 
             if (packet == null)
                 return NotFound();
 
-            var participation = await _participationService.GetById("", packet.ParticipationId);
+            var participation = await _participationService.GetById(User.Identity.Name, packet.ParticipationId);
 
             if (participation == null)
                 return NotFound();
@@ -68,12 +68,12 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
 
         public async Task<IActionResult> OnPostAsync(int packetId, PacketSubmissionModel newPacketSubmission)
         {
-            var packet = await _packetService.GetById("", packetId);
+            var packet = await _packetService.GetById(User.Identity.Name, packetId);
 
             if (packet == null)
                 return NotFound();
 
-            var participation = await _participationService.GetById("", packet.ParticipationId);
+            var participation = await _participationService.GetById(User.Identity.Name, packet.ParticipationId);
 
             if (participation == null)
                 return NotFound();

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Index.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Index.cshtml.cs
@@ -41,7 +41,7 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
                 if (packet == null)
                     return NotFound();
 
-                var participation = await _participationService.GetById("", packet.ParticipationId);
+                var participation = await _participationService.GetById(User.Identity.Name, packet.ParticipationId);
 
                 if (participation == null)
                     return NotFound();

--- a/src/UDS.Net.Forms/Pages/Participations/Edit.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/Participations/Edit.cshtml.cs
@@ -30,7 +30,7 @@ namespace UDS.Net.Forms.Pages.Participations
             if (id == null)
                 return NotFound();
 
-            var participation = await _participationService.GetById("", id.Value);
+            var participation = await _participationService.GetById(User.Identity.Name, id.Value);
 
             if (participation == null)
                 return NotFound();
@@ -49,7 +49,7 @@ namespace UDS.Net.Forms.Pages.Participations
             {
                 var participation = Participation.ToEntity();
 
-                var updatedParticipation = _participationService.Update("", participation);
+                var updatedParticipation = _participationService.Update(User.Identity.Name, participation);
 
                 if (updatedParticipation != null)
                     return RedirectToPage("Details", new { Id = participation.Id });

--- a/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
+++ b/src/UDS.Net.Forms/Pages/Visits/Details.cshtml
@@ -42,6 +42,9 @@
                                 </svg>
                                 Visit on @Model.Visit.VISIT_DATE.ToLongDateString()
                             </div>
+                            <div class="mt-2 flex items-center text-sm text-gray-500">
+                                @Model.Visit.Status.ToString()
+                            </div>
                             @if (Model.Visit.TotalUnresolvedErrorCount.HasValue && Model.Visit.TotalUnresolvedErrorCount != 0)
                             {
                                 <div class="mt-2 flex items-center text-sm">
@@ -119,7 +122,15 @@
                         <div>
                             <div class="-mt-px flex divide-x divide-gray-200">
                                 <div class="flex w-0 flex-1">
-                                    <a asp-page="/UDS@(Model.Visit.FORMVER)/@form.Kind" asp-route-id="@form.VisitId" asp-route-packetKind="@Model.Visit.PACKET" class="relative -mr-px inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-bl-lg border border-transparent py-4 text-sm font-semibold text-gray-900">Edit</a>
+                                    @if (Model.Visit.CanBeEdited)
+                                    {
+                                        <a asp-page="/UDS@(Model.Visit.FORMVER)/@form.Kind" asp-route-id="@form.VisitId" asp-route-packetKind="@Model.Visit.PACKET" class="relative -mr-px inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-bl-lg border border-transparent py-4 text-sm font-semibold text-gray-900">Edit</a>
+
+                                    }
+                                    else
+                                    {
+                                        <button type="button" disabled class="relative -mr-px inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-bl-lg border border-transparent py-4 text-sm font-semibold text-gray-300">Edit</button>
+                                    }
                                 </div>
                                 <div class="flex flex-1 items-center justify-between truncate">
                                     @{

--- a/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml
+++ b/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml
@@ -45,39 +45,27 @@
                         </div>
                     </div>
                     <div class="mt-5 flex lg:ml-4 lg:mt-0">
-                        <span class="sm:ml-3">
-                            @if (Model.Packet.CanBeFinalized)
-                            {
-                                <form method="post">
-                                    <button type="submit" class="bg-indigo-600 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm">
-                                        <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                            <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd"></path>
-                                        </svg>
-                                        Finalize and mark ready for submission
-                                    </button>
-                                </form>
-                            }
-                        </span>
+                        @if (Model.Packet.CanBeFinalized)
+                        {
+                            <form method="post">
+                                <button type="submit" class="bg-indigo-600 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm">
+                                    <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd"></path>
+                                    </svg>
+                                    Finalize and mark ready for submission
+                                </button>
+                            </form>
+                        }
                     </div>
                 </div>
             </div>
 
-            <turbo-frame>
 
-            </turbo-frame>
             <!--// Output from finalizing visit using Turbo streams //-->
             <div class="overflow-hidden rounded-md bg-white shadow m-12">
                 <ul role="list" class="divide-y divide-gray-200 text-gray-500">
                     <li class="px-6 py-4">
                         Are you sure that you want to indicate that this packet is ready for submission to NACC?
-                        <form method="post">
-                            <button type="submit" class="bg-indigo-600 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm">
-                                <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                    <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd"></path>
-                                </svg>
-                                Finalize and mark ready for submission
-                            </button>
-                        </form>
                     </li>
 
                     <!-- More items... -->

--- a/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml
+++ b/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml
@@ -6,65 +6,78 @@
 
 <div class="divide-y divide-gray-200 lg:grid lg:grid-cols-12 lg:divide-y-0 lg:divide-x">
     <div class="py-6 lg:col-span-3">
-        @if (Model.Visit != null)
+        @if (Model.Packet != null)
         {
             <nav class="space-y-1">
-                <a asp-page="Details" asp-route-id="@Model.Visit.Id" class="bg-indigo-50 border-indigo-500 text-indigo-700 hover:bg-indigo-50 hover:text-indigo-700 group border-l-4 px-3 py-2 flex items-center text-sm font-medium">
+                <a asp-page="Details" asp-route-id="@Model.Packet.Id" class="bg-indigo-50 border-indigo-500 text-indigo-700 hover:bg-indigo-50 hover:text-indigo-700 group border-l-4 px-3 py-2 flex items-center text-sm font-medium">
                     Back
                 </a>
             </nav>
         }
     </div>
     <div class="lg:col-span-9 px-5 py-6">
-        @if (Model.Visit != null)
+        @if (Model.Packet != null)
         {
             <div class="mx-auto max-w-7xl">
                 <div class="lg:flex lg:items-center lg:justify-between">
 
                     <div class="min-w-0 flex-1">
-                        <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">Packet @Model.Visit.PACKET</h2>
+                        <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">Packet @Model.Packet.PACKET</h2>
                         <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
                             <div class="mt-2 flex items-center text-sm text-gray-500">
                                 <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"></path>
                                 </svg>
-                                @("UDS" + Model.Visit.FORMVER)
+                                @("UDS" + Model.Packet.FORMVER)
                             </div>
                             <div class="mt-2 flex items-center text-sm text-gray-500">
                                 <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"></path>
                                 </svg>
-                                @Model.Visit.CreatedBy
+                                @Model.Packet.CreatedBy
                             </div>
                             <div class="mt-2 flex items-center text-sm text-gray-500">
                                 <svg class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                     <path fill-rule="evenodd" d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"></path>
                                 </svg>
-                                Visit on @Model.Visit.VISIT_DATE.ToLongDateString()
+                                Visit on @Model.Packet.VISIT_DATE.ToLongDateString()
                             </div>
                         </div>
                     </div>
                     <div class="mt-5 flex lg:ml-4 lg:mt-0">
                         <span class="sm:ml-3">
-                            @if (Model.Visit.CanBeFinalized)
+                            @if (Model.Packet.CanBeFinalized)
                             {
-                                <a asp-page="/Packets/Details" asp-route-id="@Model.Visit.Id" class="bg-indigo-600 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ">
-                                    <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                        <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd"></path>
-                                    </svg>
-                                    Ready for submission
-                                </a>
+                                <form method="post">
+                                    <button type="submit" class="bg-indigo-600 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm">
+                                        <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                            <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd"></path>
+                                        </svg>
+                                        Finalize and mark ready for submission
+                                    </button>
+                                </form>
                             }
                         </span>
                     </div>
                 </div>
             </div>
 
+            <turbo-frame>
+
+            </turbo-frame>
             <!--// Output from finalizing visit using Turbo streams //-->
             <div class="overflow-hidden rounded-md bg-white shadow m-12">
                 <ul role="list" class="divide-y divide-gray-200 text-gray-500">
                     <li class="px-6 py-4">
-                        Loading...
+                        Are you sure that you want to indicate that this packet is ready for submission to NACC?
+                        <form method="post">
+                            <button type="submit" class="bg-indigo-600 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm">
+                                <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd"></path>
+                                </svg>
+                                Finalize and mark ready for submission
+                            </button>
+                        </form>
                     </li>
 
                     <!-- More items... -->

--- a/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml.cs
@@ -1,22 +1,122 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using UDS.Net.Forms.Extensions;
 using UDS.Net.Forms.Models;
+using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Services;
+using UDS.Net.Services.DomainModels.Submission;
 
 namespace UDS.Net.Forms.Pages.Visits
 {
-    public class FinalizeModel : VisitPageModel
+    public class FinalizeModel : PageModel
     {
-        public FinalizeModel(IVisitService visitService, IParticipationService participationService) : base(visitService, participationService) { }
+        protected readonly IParticipationService _participationService;
+        protected readonly IPacketService _packetService;
+        protected readonly IVisitService _visitService;
 
-        // TODO run some checks and display results of warnings across all forms and all visits
+        [BindProperty]
+        public PacketModel? Packet { get; set; }
+
+        public string PageTitle
+        {
+            get
+            {
+                if (Packet != null)
+                {
+                    return $"Participant {Packet.Participation.LegacyId} Visit {Packet.VISITNUM} Packet Submission";
+                }
+                return "";
+            }
+        }
+
+        public FinalizeModel(IVisitService visitService, IPacketService packetService, IParticipationService participationService)
+        {
+            // we need the full packet
+            // and some previous visits
+            // and the ability to edit the visit status
+
+            _visitService = visitService;
+            _packetService = packetService;
+            _participationService = participationService;
+        }
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            if (id == null || id == 0)
+                return NotFound();
+
+            var packet = await _packetService.GetPacketWithForms(User.Identity.Name, id.Value);
+
+            if (packet == null)
+                return NotFound();
 
 
+            var participation = await _participationService.GetById(User.Identity.Name, packet.ParticipationId);
+
+            if (participation == null)
+                return NotFound();
+
+            Packet = packet.ToVM();
+
+            var a1 = Packet.Forms.Where(f => f.Kind == "A1").FirstOrDefault();
+
+            Packet.Participation = participation.ToVM();
+
+            return Page();
+        }
+
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> OnPostAsync(int id)
+        {
+            var packet = await _packetService.GetPacketWithForms(User.Identity.Name, id);
+            var participation = await _participationService.GetById(User.Identity.Name, packet.ParticipationId);
+
+            Packet = packet.ToVM();
+            Packet.Participation = participation.ToVM();
+
+            var p = Packet.ToEntity();
+            p.TryValidate();
+
+            if (!p.IsFinalizable)
+            {
+                // We shouldn't reach this point, the turbo stream should already display the results
+                // And reaching this point shouldn't be possible
+                return Page();
+            }
+
+            if (p.TryUpdateStatus(Services.Enums.PacketStatus.Finalized))
+                p.UpdateStatus(Services.Enums.PacketStatus.Finalized);
+
+            await _visitService.PatchStatus(User.Identity.Name, p);
+
+            return RedirectToAction("Index", "Visits", new { Filter = Services.Enums.PacketStatus.Finalized.ToString() });
+        }
+
+        // Called when page loads
+        [ValidateAntiForgeryToken]
+        public IEnumerable<VisitValidationResult> _Validate(int id)
+        {
+            var packet = Packet.ToEntity();
+
+            packet.TryValidate();
+
+            // TODO add a service method to get the previous packet
+
+            if (!packet.IsValid)
+            {
+                var list = packet.GetModelErrors();
+                foreach (var item in list)
+                {
+                    yield return item;
+                }
+            }
+
+            yield break;
+        }
     }
 }
-

--- a/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/Visits/Finalize.cshtml.cs
@@ -63,8 +63,6 @@ namespace UDS.Net.Forms.Pages.Visits
 
             Packet = packet.ToVM();
 
-            var a1 = Packet.Forms.Where(f => f.Kind == "A1").FirstOrDefault();
-
             Packet.Participation = participation.ToVM();
 
             return Page();

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>8.0.2</Version>
+		<Version>9.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>8.0.2</ReleaseVersion>
+		<ReleaseVersion>9.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
+++ b/src/UDS.Net.Forms/Views/Shared/_LayoutForm.cshtml
@@ -80,6 +80,7 @@
                         <input asp-for="Visit.FORMVER" type="hidden" />
                         <input asp-for="Visit.VISIT_DATE" type="hidden" />
                         <input asp-for="Visit.INITIALS" type="hidden" />
+                        <input asp-for="Visit.Status" type="hidden" />
                         <input asp-for="Visit.CreatedAt" type="hidden" />
                         <input asp-for="Visit.CreatedBy" type="hidden" />
                         <input asp-for="Visit.ModifiedBy" type="hidden" />
@@ -104,6 +105,7 @@
                         <input asp-for="Visit.FORMVER" type="hidden" />
                         <input asp-for="Visit.VISIT_DATE" type="hidden" />
                         <input asp-for="Visit.INITIALS" type="hidden" />
+                        <input asp-for="Visit.Status" type="hidden" />
                         <input asp-for="Visit.CreatedAt" type="hidden" />
                         <input asp-for="Visit.CreatedBy" type="hidden" />
                         <input asp-for="Visit.ModifiedBy" type="hidden" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>8.0.2</ReleaseVersion>
+		<ReleaseVersion>9.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
+++ b/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
@@ -14,7 +14,9 @@ namespace UDS.Net.Services.DomainModels.Submission
         {
             _submissions.Add(submission);
 
-            this.Status = PacketStatus.Submitted; // when a submission is added, the overall packet state needs to be changed as well
+            // when a submission is added, the overall packet state needs to be changed as well
+            if (TryUpdateStatus(PacketStatus.Submitted))
+                UpdateStatus(PacketStatus.Submitted);
         }
 
         public void ResolveError(PacketSubmissionError resolvedError)
@@ -38,8 +40,12 @@ namespace UDS.Net.Services.DomainModels.Submission
                 }
             }
 
+            // after all errors are resolved, state can be moved back to pending and finalization attempted again
             if (errorCount == resolvedErrorCount)
-                this.Status = PacketStatus.Pending; // after all errors are resolved, state can be moved back to pending and finalization attempted again
+            {
+                if (TryUpdateStatus(PacketStatus.Pending))
+                    UpdateStatus(PacketStatus.Pending);
+            }
         }
 
         public Packet(int id, int number, int participationId, string version, PacketKind packet, DateTime visitDate, string initials, PacketStatus status, DateTime createdAt, string createdBy, string modifiedBy, string deletedBy, bool isDeleted, IList<Form> existingForms, IList<PacketSubmission> packetSubmissions) : base(id, number, participationId, version, packet, visitDate, initials, status, createdAt, createdBy, modifiedBy, deletedBy, isDeleted, existingForms)

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -29,7 +29,7 @@ namespace UDS.Net.Services.DomainModels
 
         public string INITIALS { get; set; }
 
-        public PacketStatus Status { get; set; }
+        public PacketStatus Status { get; private set; }
 
         public DateTime CreatedAt { get; set; }
 
@@ -51,20 +51,20 @@ namespace UDS.Net.Services.DomainModels
 
         }
 
+        /// <summary>
+        /// This only checks if it could be finalized, not that it follows the rules for status changes
+        /// </summary>
         public bool IsFinalizable
         {
             get
             {
-                // if ti has been submitted and error results are pending
-                if (this.Status == PacketStatus.Submitted)
-                    return false;
+                bool finalizable = false;
 
-                // if it has already been submitted and it has unresolved errors
+                // double check that it does not have unresolved errors
                 if (this.UnresolvedErrorCount.HasValue && this.UnresolvedErrorCount.Value > 0)
                     return false;
 
-                bool finalizable = false;
-
+                // now check that all the forms follow the contract to be finalized
                 if (this.Forms != null && this.Forms.Count() > 0 && _formsContract != null)
                 {
                     var packetKindFormsContract = _formsContract.Where(u => u.Key == this.PACKET.ToString()).FirstOrDefault();
@@ -218,6 +218,57 @@ namespace UDS.Net.Services.DomainModels
 
         //public int Count { get; private set; }
 
+        public bool TryUpdateStatus(PacketStatus status)
+        {
+            bool updatePossible = false;
+            if (this.Status == PacketStatus.Pending)
+            {
+                if (status == PacketStatus.Pending)
+                    updatePossible = true;
+                else if (status == PacketStatus.Finalized)
+                {
+                    if (this.IsFinalizable)
+                        updatePossible = true;
+                }
+            }
+            else if (this.Status == PacketStatus.Finalized)
+            {
+                if (status == PacketStatus.Pending)
+                    updatePossible = true; // revert
+                else if (status == PacketStatus.Submitted)
+                    updatePossible = true;
+            }
+            else if (this.Status == PacketStatus.FailedErrorChecks)
+            {
+                // when errors are attempted to be resolved status can be moved back to pending
+                if (status == PacketStatus.Pending)
+                    updatePossible = true;
+            }
+            else if (this.Status == PacketStatus.PassedErrorChecks)
+            {
+                if (status == PacketStatus.Pending)
+                    updatePossible = true;
+                else if (status == PacketStatus.Frozen)
+                    updatePossible = true;
+            }
+            else if (this.Status == PacketStatus.Frozen)
+            {
+                if (status == PacketStatus.Pending)
+                    updatePossible = true;
+            }
+            return updatePossible;
+        }
+
+        public bool UpdateStatus(PacketStatus status)
+        {
+            if (TryUpdateStatus(status))
+            {
+                this.Status = status;
+                return true;
+            }
+            return false;
+        }
+
         public Visit(int id, int number, int participationId, string version, PacketKind packet, DateTime visitDate, string initials, PacketStatus status, DateTime createdAt, string createdBy, string modifiedBy, string deletedBy, bool isDeleted, IList<Form> existingForms)
         {
             Id = id;
@@ -283,14 +334,57 @@ namespace UDS.Net.Services.DomainModels
         public bool TryValidate()
         {
             // TODO validate the visit against any rules that might have changed due to form fields changing
-            GetModelErrors();
-            return true;
+            var errors = GetModelErrors();
+            if (errors != null && errors.Count() > 0)
+                return false;
+            else
+                return true;
         }
+
+        // Iterator method in c# retrieves elements one by one
+        //public virtual IEnumerable<VisitValidationResult> GetModelErrors()
+        //{
+        //    /// TODO For example, in UDS3 FVP, either C1 or C2 is required, but not both
+
+        //    // A1 sex and D1a menstruation
+        //    var a1 = (A1FormFields)this.Forms.Where(f => f.Kind == "A1").Select(f => f.Fields).FirstOrDefault();
+        //    var a5d2 = (A5D2FormFields)this.Forms.Where(f => f.Kind == "A5D2").Select(f => f.Fields).FirstOrDefault();
+
+        //    if (PACKET == PacketKind.I || PACKET == PacketKind.I4)
+        //    {
+        //        if (a1.BIRTHSEX == 0 && a5d2.MENARCHE != null)
+        //        {
+        //            yield return new VisitValidationResult(
+        //                $"A1 sex cannot be male and A5D2 menstration details be provi.",
+        //                new[] { nameof(a1.BIRTHSEX), nameof(a5d2.MENARCHE) });
+        //        }
+        //    }
+
+        //    yield break;
+        //}
 
         public IEnumerable<VisitValidationResult> GetModelErrors()
         {
-            /// TODO For example, in UDS3 FVP, either C1 or C2 is required, but not both
-            yield break;
+            List<VisitValidationResult> results = new List<VisitValidationResult>();
+
+            if (PACKET == PacketKind.I || PACKET == PacketKind.I4)
+            {
+                // A1 sex and D1a menstruation
+                var a1 = (A1FormFields)this.Forms.Where(f => f.Kind == "A1").Select(f => f.Fields).FirstOrDefault();
+                var a5d2 = (A5D2FormFields)this.Forms.Where(f => f.Kind == "A5D2").Select(f => f.Fields).FirstOrDefault();
+
+                if (a1 != null && a5d2 != null)
+                {
+                    if (a1.BIRTHSEX == 0 && a5d2.MENARCHE != null)
+                    {
+                        results.Add(new VisitValidationResult(
+                            $"A1 sex cannot be male and A5D2 menstration details be provi.",
+                            new[] { nameof(a1.BIRTHSEX), nameof(a5d2.MENARCHE) }));
+                    }
+                }
+            }
+
+            return results;
         }
     }
 }

--- a/src/UDS.Net.Services/IVisitService.cs
+++ b/src/UDS.Net.Services/IVisitService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using UDS.Net.Services.DomainModels;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Services
 {
@@ -21,6 +22,14 @@ namespace UDS.Net.Services
         Task<IEnumerable<Visit>> ListByStatus(string username, int pageSize = 10, int pageIndex = 1, string[] filterItems = null);
 
         Task<int> CountByStatus(string username, string[] statuses = null);
+
+        /// <summary>
+        /// Only updates the status on the visit
+        /// </summary>
+        /// <param name="username">User modifying the status</param>
+        /// <param name="entity">Visit with the new status</param>
+        /// <returns>Updated visit</returns>
+        Task<Visit> PatchStatus(string username, Visit entity);
     }
 }
 

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>8.0.2</Version>
+		<Version>9.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>8.0.2</ReleaseVersion>
+		<ReleaseVersion>9.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="7.0.0" />

--- a/src/UDS.Net.Services/VisitValidationResult.cs
+++ b/src/UDS.Net.Services/VisitValidationResult.cs
@@ -3,8 +3,15 @@ namespace UDS.Net.Services
 {
     public class VisitValidationResult
     {
-        public string MemberName { get; set; }
+        public string[] MemberNames { get; set; }
         public string ErrorMessage { get; set; }
+
+        public VisitValidationResult(string errorMessage, string[] memberNames)
+        {
+            this.ErrorMessage = errorMessage;
+            this.MemberNames = memberNames;
+        }
+
     }
 }
 

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>8.0.2</Version>
+		<Version>9.0.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>8.0.2</ReleaseVersion>
+		<ReleaseVersion>9.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/VisitService.cs
+++ b/src/UDS.Net.Web.MVC.Services/VisitService.cs
@@ -6,6 +6,7 @@ using UDS.Net.API.Client;
 using UDS.Net.Dto;
 using UDS.Net.Services;
 using UDS.Net.Services.DomainModels;
+using UDS.Net.Services.Enums;
 using UDS.Net.Services.Extensions;
 
 namespace UDS.Net.Web.MVC.Services
@@ -175,6 +176,16 @@ namespace UDS.Net.Web.MVC.Services
             // In this implementation we are sorting by kind alphabetically, but other organizations may want the flexibilty to order forms by another parameter.
             var visit = await GetById(username, visitId);
             return visit.Forms.OrderBy(f => f.Kind).Select(f => f.Kind).ToList();
+        }
+
+        public async Task<Visit> PatchStatus(string username, Visit entity)
+        {
+            if (entity == null)
+                return null;
+
+            var dto = await _apiClient.VisitClient.Put(entity.Id, entity.ToDto());
+
+            return dto.ToDomain(username);
         }
     }
 }

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>8.0.2</ReleaseVersion>
+		<ReleaseVersion>9.0.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -15,7 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC.Services", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
 EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{D34AFEAA-EC74-4D62-883C-64A7B76A6F4B}"
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{50CF3306-BB94-4DA3-B70F-27459ACB6789}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,10 +47,10 @@ Global
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{332BFB18-1431-4572-BE96-757D0221FBCE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D34AFEAA-EC74-4D62-883C-64A7B76A6F4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D34AFEAA-EC74-4D62-883C-64A7B76A6F4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D34AFEAA-EC74-4D62-883C-64A7B76A6F4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D34AFEAA-EC74-4D62-883C-64A7B76A6F4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50CF3306-BB94-4DA3-B70F-27459ACB6789}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50CF3306-BB94-4DA3-B70F-27459ACB6789}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50CF3306-BB94-4DA3-B70F-27459ACB6789}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50CF3306-BB94-4DA3-B70F-27459ACB6789}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +59,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 8.0.2
+		version = 9.0.0
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Supports some finalization and some rules with visit statuses and when forms can be edited.

## Pending status, forms can be edited
<img width="1226" alt="Screenshot 2025-03-27 at 8 48 44 PM" src="https://github.com/user-attachments/assets/063eb7f8-7524-4267-bb43-abeef63bdcd0" />

## Finalized status, forms can be edited and status will go back to pending
<img width="1224" alt="Screenshot 2025-03-27 at 8 46 05 PM" src="https://github.com/user-attachments/assets/5b006739-57fa-4664-a35e-cdeb5964e0f4" />

## Submitted status, forms cannot  be edited
<img width="1226" alt="Screenshot 2025-03-27 at 8 45 53 PM" src="https://github.com/user-attachments/assets/b694526e-206e-4e89-b5cd-b1fe47422342" />

## Pending and all required forms are finalized so the visit can also be finalized
<img width="1221" alt="Screenshot 2025-03-27 at 8 57 50 PM" src="https://github.com/user-attachments/assets/e7860943-6126-4e5f-b71e-bc27e5e2b3a5" />

## Finalization, prompts the user to confirm that packet is ready for submission
<img width="1239" alt="Screenshot 2025-03-27 at 9 00 20 PM" src="https://github.com/user-attachments/assets/20ec73ad-77da-4099-bf78-70e4f6b8970c" />

