### PR TITLE
Adjust text and validation for d1a 8a-8l

### DIFF
--- a/src/UDS.Net.Forms/Models/UDS4/D1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/D1a.cs
@@ -292,12 +292,7 @@ namespace UDS.Net.Forms.Models.UDS4
                     if (MSASYN.HasValue && MSASYN.Value == true) PREDOMSYNSyndromeCount++;
                     if (OTHSYN.HasValue && OTHSYN.Value == true) PREDOMSYNSyndromeCount++;
 
-                    if (PREDOMSYNSyndromeCount == 0)
-                    {
-                        return null;
-                    }
-
-                    if (PREDOMSYNSyndromeCount > 1)
+                    if (PREDOMSYNSyndromeCount == 0 || PREDOMSYNSyndromeCount > 1)
                     {
                         return null;
                     }

--- a/src/UDS.Net.Forms/Models/UDS4/D1a.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/D1a.cs
@@ -268,7 +268,7 @@ namespace UDS.Net.Forms.Models.UDS4
         [Display(Name = "Is there a predominant clinical syndrome?")]
         public int? PREDOMSYN { get; set; }
 
-        [RequiredIf(nameof(PREDOMSYN), "1", ErrorMessage = "If a predominant clinical syndrome was present in question 8, a dementia syndrome must be marked as present")]
+        [RequiredIf(nameof(PREDOMSYN), "1", ErrorMessage = "If a predominant clinical syndrome was present in question 8, only a single dementia syndrome must be marked as present")]
         [NotMapped]
         public bool? PREDOMSYNSyndromePresent
         {
@@ -276,7 +276,7 @@ namespace UDS.Net.Forms.Models.UDS4
             {
                 if (PREDOMSYN == 1)
                 {
-                    //one of the 8 sub qustions must be present
+                    //only one of the 8 sub qustions can and must be marked as present
                     var PREDOMSYNSyndromeCount = 0;
 
                     if (AMNDEM.HasValue && AMNDEM.Value == true) PREDOMSYNSyndromeCount++;
@@ -293,6 +293,11 @@ namespace UDS.Net.Forms.Models.UDS4
                     if (OTHSYN.HasValue && OTHSYN.Value == true) PREDOMSYNSyndromeCount++;
 
                     if (PREDOMSYNSyndromeCount == 0)
+                    {
+                        return null;
+                    }
+
+                    if (PREDOMSYNSyndromeCount > 1)
                     {
                         return null;
                     }

--- a/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
@@ -564,10 +564,6 @@
         section in Form D1b). This is not always possible and thus Q9 allows centers to record when biomarker data is known and may have
         influenced the clinical diagnosis.
     </p>
-    <p class="mt-2 text-sm text-gray-900">
-        Select applicable syndrome(s) as present; all others will default to Absent in the NACC database. Note that a participant may not
-        meet any clinical criteria (for instance, this is common for MCI and “impaired, not MCI”). In this case, leave 8a-8l blank.
-    </p>
 </div>
 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
     <label asp-for="D1a.PREDOMSYN"><span class="counter"></span> @Html.DisplayNameFor(m => m.D1a.PREDOMSYN)</label>
@@ -578,6 +574,9 @@
     </div>
 </div>
 <div class="sm:grid sm:grid-cols-1 sm:items-start sm:gap-4 sm:py-6">
+    <p class="mt-2 text-sm text-gray-900">
+        Select the predominant syndrome as present; all others will default to Absent in the NACC database.
+    </p>
     <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.PREDOMSYNSyndromePresent"></span>
     <table class="ml-2 table-auto min-w-full divide-y divide-gray-300">
         <thead>

--- a/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml
@@ -566,9 +566,14 @@
     </p>
 </div>
 <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
-    <label asp-for="D1a.PREDOMSYN"><span class="counter"></span> @Html.DisplayNameFor(m => m.D1a.PREDOMSYN)</label>
+    <div>
+        <label asp-for="D1a.PREDOMSYN"><span class="counter"></span> @Html.DisplayNameFor(m => m.D1a.PREDOMSYN)</label>
+        <p class="text-sm italic text-gray-500">
+            Note that the participant may not meet any clinical criteria or may not have a predominant syndrome
+            (for instance, this is common for MCI and “impaired, not MCI”). In this case, select “No.”
+        </p>
+    </div>
     <div class="mt-4 sm:col-span-2 sm:mt-0">
-        <p class="text-sm text-gray-500" asp-description-for="@Model.D1a.PREDOMSYN"></p>
         <radio-button-group id="@Html.IdFor(m => m.D1a.PREDOMSYN)" for="@Model.D1a.PREDOMSYN" items="Model.PREDOMSYNListItems" ui-behaviors="Model.PREDOMSYNUIBehavior"></radio-button-group>
         <span class="mt-2 text-sm text-red-600" asp-validation-for="D1a.PREDOMSYN"></span>
     </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1a.cshtml.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using UDS.Net.Forms.Extensions;
+﻿using Microsoft.AspNetCore.Mvc;
 using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Forms.Models.UDS4;
 using UDS.Net.Forms.TagHelpers;


### PR DESCRIPTION
Fixes #380 

# Adjust validation and text for D1a
- [x] D1a, 8a - 8l no longer allows for multiple checkmarks to be checked. Rules state that ONE should be checked when PREDOMSYN = 1
- [x] Text was adjusted to match the PDF NACC form
  - [x] Text was moved to be above question 8a
  - [x] Text was adjusted to remove reference to multiple syndromes marked and matches the NACC pdf form 

 ### Text in the PDF NACC guide
  - ![image](https://github.com/user-attachments/assets/285a2e7f-250b-4e79-9192-4d19649dbfa9)

### Error returned from NACC validation check
- **FORM D1A**: if q8. predomsyn (is there a predominant clinical syndrome?)=1 (yes) then exactly one of the following variables should equal 1 (present): q8a. amndem, q8b. dyexecsyn, q8c. pca, q8d. ppasyn, q8e. ftdsyn, q8f. lbdsyn, q8g. namndem, q8h. pspsyn, q8i. ctesyn, q8j. cbssyn, q8k. msasyn, q8l. othsyn 
