### PR TITLE
Adjust record dates formats

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>9.0.9</ReleaseVersion>
+		<ReleaseVersion>9.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Records/A1Record.cs
+++ b/src/UDS.Net.Forms/Records/A1Record.cs
@@ -11,7 +11,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatea1")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsa1")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/A1aRecord.cs
+++ b/src/UDS.Net.Forms/Records/A1aRecord.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatea1a")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsa1a")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/A2Record.cs
+++ b/src/UDS.Net.Forms/Records/A2Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatea2")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsa2")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/A3Record.cs
+++ b/src/UDS.Net.Forms/Records/A3Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatea3")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsa3")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/A4Record.cs
+++ b/src/UDS.Net.Forms/Records/A4Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatea4")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsa4")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/A4aRecord.cs
+++ b/src/UDS.Net.Forms/Records/A4aRecord.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatea4a")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsa4a")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/A5D2Record.cs
+++ b/src/UDS.Net.Forms/Records/A5D2Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatea5d2")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsa5d2")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B1Record.cs
+++ b/src/UDS.Net.Forms/Records/B1Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb1")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb1")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B3Record.cs
+++ b/src/UDS.Net.Forms/Records/B3Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb3")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb3")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B4Record.cs
+++ b/src/UDS.Net.Forms/Records/B4Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb4")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb4")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B5Record.cs
+++ b/src/UDS.Net.Forms/Records/B5Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb5")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb5")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B6Record.cs
+++ b/src/UDS.Net.Forms/Records/B6Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb6")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb6")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B7Record.cs
+++ b/src/UDS.Net.Forms/Records/B7Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb7")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb7")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B8Record.cs
+++ b/src/UDS.Net.Forms/Records/B8Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb8")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb8")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/B9Record.cs
+++ b/src/UDS.Net.Forms/Records/B9Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdateb9")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsb9")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/C2Record.cs
+++ b/src/UDS.Net.Forms/Records/C2Record.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdatec2c2t")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsc2c2t")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/CsvRecord.cs
+++ b/src/UDS.Net.Forms/Records/CsvRecord.cs
@@ -32,7 +32,7 @@ namespace UDS.Net.Forms.Records
 
         [Index(6)]
         [Name("visitdate")]
-        public string VisitDate { get; init; } = visit.VISIT_DATE.ToString("dd-MM-yyyy");
+        public string VisitDate { get; init; } = visit.VISIT_DATE.ToString(RecordConstants.dateFormatString);
     }
 }
 

--- a/src/UDS.Net.Forms/Records/D1aRecord.cs
+++ b/src/UDS.Net.Forms/Records/D1aRecord.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdated1a")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsd1a")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/D1bRecord.cs
+++ b/src/UDS.Net.Forms/Records/D1bRecord.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Records
         internal Form form { get; init; }
 
         [Name("frmdated1b")]
-        public string FrmDate { get; init; } = form.FRMDATE.ToString("MM-dd-yyyy");
+        public string FrmDate { get; init; } = form.FRMDATE.ToString(RecordConstants.dateFormatString);
 
         [Name("initialsd1b")]
         public string Initials { get; init; } = form.INITIALS;

--- a/src/UDS.Net.Forms/Records/RecordConstants.cs
+++ b/src/UDS.Net.Forms/Records/RecordConstants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UDS.Net.Forms.Records
+{
+    public static class RecordConstants
+    {
+        public const string dateFormatString = "MM-dd-yyyy";
+    }
+}

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>9.0.9</Version>
+		<Version>9.0.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.9</ReleaseVersion>
+		<ReleaseVersion>9.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>9.0.9</ReleaseVersion>
+		<ReleaseVersion>9.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>9.0.9</Version>
+		<Version>9.0.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.9</ReleaseVersion>
+		<ReleaseVersion>9.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="7.0.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>9.0.9</Version>
+		<Version>9.0.10</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.9</ReleaseVersion>
+		<ReleaseVersion>9.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>9.0.9</ReleaseVersion>
+		<ReleaseVersion>9.0.10</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Fixes: #390 

# fix visit date format in export
- [x] Visit date now matches the format used in the other records
- [x] As per a suggestion, a public const was used to reference date formats for all records in the export to make adjustments to date format easier in the future if needed
- [x] Export now exports all dates in the correct format

### Visit date now matches frmdate formats
- While showing in Excel as '8/5/2024' , the export is sending '08/05/2024' to the .csv file. Excel just auto formats on view
- While the forms could have different dates, this example is just to show that the date is not reversed when exported 

![image](https://github.com/user-attachments/assets/13253138-6c3d-4a23-ad6b-3e016ceb1410)
