### PR TITLE
C2 MOCATOTS sum validation

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>9.0.13</ReleaseVersion>
+		<ReleaseVersion>9.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -786,12 +786,12 @@ namespace UDS.Net.Forms.Models.UDS4
 
         //MOCATOTS = sum of 1g-1l, 1n-1t, and 1w-1bb when all these sub questions are < 95
         [NotMapped]
-        [RequiredOnFinalized(ErrorMessage = "If questions 1g-1l, 1n-1t, and 1w-1bb are all completed, the Total Raw Score - Uncorrected needs to be the sum of these answers.")]
+        [RequiredIfInPersonVisit(nameof(MOCACOMP), "1", ErrorMessage = "If questions 1g-1l, 1n-1t, and 1w-1bb are all completed, the Total Raw Score - Uncorrected needs to be the sum of these answers.")]
         public bool? MOCATOTSSumValidation
         {
             get
             {
-                if (MOCATOTS.HasValue)
+                if (MOCATOTS.HasValue && MOCATOTS != 88)
                 {
                     int questionsSum = 0;
                     int questionsCount = 0;

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -823,7 +823,7 @@ namespace UDS.Net.Forms.Models.UDS4
                     if (questionsCount == 19)
                     {
                         return MOCATOTS.Value == questionsSum ? true : null;
-                    }  
+                    }
                 }
 
                 return true;

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -784,6 +784,76 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
+        [NotMapped]
+        [RequiredOnFinalized]
+        public bool? MOCATOTSSumValidation
+        {
+            get
+            {
+                if (MOCATOTS.HasValue)
+                {
+                    int MOCATOTSSubQuestionsSum = 0;
+                    int MOCATOTSSubQuestionsCount = 0;
+
+                    //C2 in-person & video modalities
+                    if (MODE == FormMode.InPerson || MODE == FormMode.Remote && RMMODE == RemoteModality.Video)
+                    {
+                        if (MOCATRAI.HasValue && MOCATRAI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCATRAI.Value; }
+                        if (MOCACUBE.HasValue && MOCACUBE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACUBE.Value; }
+                        if (MOCACLOC.HasValue && MOCACLOC.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACLOC.Value; }
+                        if (MOCACLON.HasValue && MOCACLON.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACLON.Value; }
+                        if (MOCACLOH.HasValue && MOCACLOH.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACLOH.Value; }
+                        if (MOCANAMI.HasValue && MOCANAMI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCANAMI.Value; }
+                        if (MOCADIGI.HasValue && MOCADIGI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCADIGI.Value; }
+                        if (MOCALETT.HasValue && MOCALETT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCALETT.Value; }
+                        if (MOCASER7.HasValue && MOCASER7.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCASER7.Value; }
+                        if (MOCAREPE.HasValue && MOCAREPE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAREPE.Value; }
+                        if (MOCAFLUE.HasValue && MOCAFLUE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAFLUE.Value; }
+                        if (MOCAABST.HasValue && MOCAABST.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAABST.Value; }
+                        if (MOCARECN.HasValue && MOCARECN.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCARECN.Value; }
+                        if (MOCAORDT.HasValue && MOCAORDT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDT.Value; }
+                        if (MOCAORMO.HasValue && MOCAORMO.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORMO.Value; }
+                        if (MOCAORYR.HasValue && MOCAORYR.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORYR.Value; }
+                        if (MOCAORDY.HasValue && MOCAORDY.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDY.Value; }
+                        if (MOCAORPL.HasValue && MOCAORPL.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORPL.Value; }
+                        if (MOCAORCT.HasValue && MOCAORCT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORCT.Value; }
+                    }
+
+                    //C2T telephone modality
+                    if (MODE == FormMode.Remote && RMMODE == RemoteModality.Telephone)
+                    {
+                        if (MOCADIGI.HasValue && MOCADIGI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCADIGI.Value; }
+                        if (MOCALETT.HasValue && MOCALETT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCALETT.Value; }
+                        if (MOCASER7.HasValue && MOCASER7.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCASER7.Value; }
+                        if (MOCAREPE.HasValue && MOCAREPE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAREPE.Value; }
+                        if (MOCAFLUE.HasValue && MOCAFLUE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAFLUE.Value; }
+                        if (MOCAABST.HasValue && MOCAABST.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAABST.Value; }
+                        if (MOCARECN.HasValue && MOCARECN.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCARECN.Value; }
+                        if (MOCAORDT.HasValue && MOCAORDT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDT.Value; }
+                        if (MOCAORMO.HasValue && MOCAORMO.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORMO.Value; }
+                        if (MOCAORYR.HasValue && MOCAORYR.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORYR.Value; }
+                        if (MOCAORDY.HasValue && MOCAORDY.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDY.Value; }
+                        if (MOCAORPL.HasValue && MOCAORPL.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORPL.Value; }
+                        if (MOCAORCT.HasValue && MOCAORCT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORCT.Value; }
+                    }
+
+                    //In-person & video modalities: If all sub questions answered, MOCATOTS must be the sum of answered questions
+                    if (MOCATOTSSubQuestionsCount == 19)
+                    {
+                        return MOCATOTS.Value == MOCATOTSSubQuestionsSum ? true : false;
+                    }
+
+                    //Telephone modality: If all sub questions answered, MOCATOTS must be the sum of answered questions
+                    if (MOCATOTSSubQuestionsCount == 13)
+                    {
+                        return MOCATOTS.Value == MOCATOTSSubQuestionsSum ? true : false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             if (Status == Services.Enums.FormStatus.Finalized)

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -784,70 +784,46 @@ namespace UDS.Net.Forms.Models.UDS4
             }
         }
 
+        //MOCATOTS = sum of 1g-1l, 1n-1t, and 1w-1bb when all these sub questions are < 95
         [NotMapped]
-        [RequiredOnFinalized]
-        public bool? MOCATOTSSumValidation
+        [RequiredOnFinalized(ErrorMessage = "If questions 1g-1l, 1n-1t, and 1w-1bb are all completed, the Total Raw Score - Uncorrected needs to be the sum of these answers.")]
+        public bool? MOCATOTSInPersonValidation
         {
             get
             {
                 if (MOCATOTS.HasValue)
                 {
-                    int MOCATOTSSubQuestionsSum = 0;
-                    int MOCATOTSSubQuestionsCount = 0;
+                    int questionsSum = 0;
+                    int questionsCount = 0;
 
-                    //C2 in-person & video modalities
-                    if (MODE == FormMode.InPerson || MODE == FormMode.Remote && RMMODE == RemoteModality.Video)
+                    if (MODE == FormMode.InPerson || RMMODE == RemoteModality.Video)
                     {
-                        if (MOCATRAI.HasValue && MOCATRAI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCATRAI.Value; }
-                        if (MOCACUBE.HasValue && MOCACUBE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACUBE.Value; }
-                        if (MOCACLOC.HasValue && MOCACLOC.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACLOC.Value; }
-                        if (MOCACLON.HasValue && MOCACLON.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACLON.Value; }
-                        if (MOCACLOH.HasValue && MOCACLOH.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCACLOH.Value; }
-                        if (MOCANAMI.HasValue && MOCANAMI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCANAMI.Value; }
-                        if (MOCADIGI.HasValue && MOCADIGI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCADIGI.Value; }
-                        if (MOCALETT.HasValue && MOCALETT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCALETT.Value; }
-                        if (MOCASER7.HasValue && MOCASER7.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCASER7.Value; }
-                        if (MOCAREPE.HasValue && MOCAREPE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAREPE.Value; }
-                        if (MOCAFLUE.HasValue && MOCAFLUE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAFLUE.Value; }
-                        if (MOCAABST.HasValue && MOCAABST.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAABST.Value; }
-                        if (MOCARECN.HasValue && MOCARECN.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCARECN.Value; }
-                        if (MOCAORDT.HasValue && MOCAORDT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDT.Value; }
-                        if (MOCAORMO.HasValue && MOCAORMO.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORMO.Value; }
-                        if (MOCAORYR.HasValue && MOCAORYR.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORYR.Value; }
-                        if (MOCAORDY.HasValue && MOCAORDY.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDY.Value; }
-                        if (MOCAORPL.HasValue && MOCAORPL.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORPL.Value; }
-                        if (MOCAORCT.HasValue && MOCAORCT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORCT.Value; }
+                        if (MOCATRAI.HasValue && MOCATRAI.Value < 95) { questionsCount++; questionsSum += MOCATRAI.Value; }
+                        if (MOCACUBE.HasValue && MOCACUBE.Value < 95) { questionsCount++; questionsSum += MOCACUBE.Value; }
+                        if (MOCACLOC.HasValue && MOCACLOC.Value < 95) { questionsCount++; questionsSum += MOCACLOC.Value; }
+                        if (MOCACLON.HasValue && MOCACLON.Value < 95) { questionsCount++; questionsSum += MOCACLON.Value; }
+                        if (MOCACLOH.HasValue && MOCACLOH.Value < 95) { questionsCount++; questionsSum += MOCACLOH.Value; }
+                        if (MOCANAMI.HasValue && MOCANAMI.Value < 95) { questionsCount++; questionsSum += MOCANAMI.Value; }
+                        if (MOCADIGI.HasValue && MOCADIGI.Value < 95) { questionsCount++; questionsSum += MOCADIGI.Value; }
+                        if (MOCALETT.HasValue && MOCALETT.Value < 95) { questionsCount++; questionsSum += MOCALETT.Value; }
+                        if (MOCASER7.HasValue && MOCASER7.Value < 95) { questionsCount++; questionsSum += MOCASER7.Value; }
+                        if (MOCAREPE.HasValue && MOCAREPE.Value < 95) { questionsCount++; questionsSum += MOCAREPE.Value; }
+                        if (MOCAFLUE.HasValue && MOCAFLUE.Value < 95) { questionsCount++; questionsSum += MOCAFLUE.Value; }
+                        if (MOCAABST.HasValue && MOCAABST.Value < 95) { questionsCount++; questionsSum += MOCAABST.Value; }
+                        if (MOCARECN.HasValue && MOCARECN.Value < 95) { questionsCount++; questionsSum += MOCARECN.Value; }
+                        if (MOCAORDT.HasValue && MOCAORDT.Value < 95) { questionsCount++; questionsSum += MOCAORDT.Value; }
+                        if (MOCAORMO.HasValue && MOCAORMO.Value < 95) { questionsCount++; questionsSum += MOCAORMO.Value; }
+                        if (MOCAORYR.HasValue && MOCAORYR.Value < 95) { questionsCount++; questionsSum += MOCAORYR.Value; }
+                        if (MOCAORDY.HasValue && MOCAORDY.Value < 95) { questionsCount++; questionsSum += MOCAORDY.Value; }
+                        if (MOCAORPL.HasValue && MOCAORPL.Value < 95) { questionsCount++; questionsSum += MOCAORPL.Value; }
+                        if (MOCAORCT.HasValue && MOCAORCT.Value < 95) { questionsCount++; questionsSum += MOCAORCT.Value; }
                     }
 
-                    //C2T telephone modality
-                    if (MODE == FormMode.Remote && RMMODE == RemoteModality.Telephone)
+                    //number of sub questions
+                    if (questionsCount == 19)
                     {
-                        if (MOCADIGI.HasValue && MOCADIGI.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCADIGI.Value; }
-                        if (MOCALETT.HasValue && MOCALETT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCALETT.Value; }
-                        if (MOCASER7.HasValue && MOCASER7.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCASER7.Value; }
-                        if (MOCAREPE.HasValue && MOCAREPE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAREPE.Value; }
-                        if (MOCAFLUE.HasValue && MOCAFLUE.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAFLUE.Value; }
-                        if (MOCAABST.HasValue && MOCAABST.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAABST.Value; }
-                        if (MOCARECN.HasValue && MOCARECN.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCARECN.Value; }
-                        if (MOCAORDT.HasValue && MOCAORDT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDT.Value; }
-                        if (MOCAORMO.HasValue && MOCAORMO.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORMO.Value; }
-                        if (MOCAORYR.HasValue && MOCAORYR.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORYR.Value; }
-                        if (MOCAORDY.HasValue && MOCAORDY.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORDY.Value; }
-                        if (MOCAORPL.HasValue && MOCAORPL.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORPL.Value; }
-                        if (MOCAORCT.HasValue && MOCAORCT.Value < 95) { MOCATOTSSubQuestionsSum++; MOCATOTSSubQuestionsCount += MOCAORCT.Value; }
-                    }
-
-                    //In-person & video modalities: If all sub questions answered, MOCATOTS must be the sum of answered questions
-                    if (MOCATOTSSubQuestionsCount == 19)
-                    {
-                        return MOCATOTS.Value == MOCATOTSSubQuestionsSum ? true : false;
-                    }
-
-                    //Telephone modality: If all sub questions answered, MOCATOTS must be the sum of answered questions
-                    if (MOCATOTSSubQuestionsCount == 13)
-                    {
-                        return MOCATOTS.Value == MOCATOTSSubQuestionsSum ? true : false;
-                    }
+                        return MOCATOTS.Value == questionsSum ? true : null;
+                    }  
                 }
 
                 return true;

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -787,7 +787,7 @@ namespace UDS.Net.Forms.Models.UDS4
         //MOCATOTS = sum of 1g-1l, 1n-1t, and 1w-1bb when all these sub questions are < 95
         [NotMapped]
         [RequiredOnFinalized(ErrorMessage = "If questions 1g-1l, 1n-1t, and 1w-1bb are all completed, the Total Raw Score - Uncorrected needs to be the sum of these answers.")]
-        public bool? MOCATOTSInPersonValidation
+        public bool? MOCATOTSSumValidation
         {
             get
             {

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -89,7 +89,7 @@
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCATOTS"></p>
                 </div>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCATOTS"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCATOTSInPersonValidation"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCATOTSSumValidation"></span>
             </div>
 
             <div class="@rowCSS">

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -89,6 +89,7 @@
                     <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.MOCATOTS"></p>
                 </div>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCATOTS"></span>
+                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.MOCATOTSInPersonValidation"></span>
             </div>
 
             <div class="@rowCSS">

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>9.0.13</Version>
+		<Version>9.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.13</ReleaseVersion>
+		<ReleaseVersion>9.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>9.0.13</ReleaseVersion>
+		<ReleaseVersion>9.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>9.0.13</Version>
+		<Version>9.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.13</ReleaseVersion>
+		<ReleaseVersion>9.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="7.0.0" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>9.0.13</Version>
+		<Version>9.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.13</ReleaseVersion>
+		<ReleaseVersion>9.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>9.0.13</ReleaseVersion>
+		<ReleaseVersion>9.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves: #394 

Apply validation for MOCATOTS to be the sum of questions  1g-1l, 1n-1t, and 1w-1bb when these questions are all completed (i.e all questions described have a value of < 95)

![image](https://github.com/user-attachments/assets/a840e28b-0b16-4c47-8964-d11091cdd170)


### Sub question property names (1g-1l, 1n-1t, and 1w-1bb):
MOCATRAI,
MOCACUBE,
MOCACLOC,
MOCACLON,
MOCACLOH,
MOCANAMI,
MOCADIGI,
MOCALETT,
MOCASER7,
MOCAREPE,
MOCAFLUE,
MOCAABST,
MOCARECN,
MOCAORDT,
MOCAORMO,
MOCAORYR,
MOCAORDY,
MOCAORPL,
MOCAORCT


### Review checklist
- [x] Validation for MOCATOTS applies to both in person and remote/video modalities
- [x] When MOCATOTS value does not equal the sum of the values of sub questions and error will return
- [x] When 95 is supplied for a sub question and 88 is given to MOCATOTS then validation should allow for a finalize save
- [x] Remote/Telephone is not effected by this change and still saves 