### PR TITLE
Packet Submission Visit PassedErrorChecks and FailedErrorChecks Initial Workflow

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>9.0.16</ReleaseVersion>
+		<ReleaseVersion>9.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/UDS.Net.Forms/Extensions/ViewModelToDomainMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/ViewModelToDomainMapper.cs
@@ -93,7 +93,7 @@ namespace UDS.Net.Forms.Extensions
 
         public static PacketSubmission ToEntity(this PacketSubmissionModel vm)
         {
-            return new PacketSubmission(vm.Id, "", vm.SubmissionDate, vm.PacketId, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, "", false, 0);
+            return new PacketSubmission(vm.Id, "", vm.SubmissionDate, vm.PacketId, vm.CreatedAt, vm.CreatedBy, vm.ModifiedBy, "", false, null);
         }
 
         public static List<Form> ToEntity(this IList<FormModel> vm)

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml
@@ -3,7 +3,3 @@
 @{
     ViewData["Title"] = "Edit packet submission";
 }
-
-@* Marvin dev: The packet submission edit view *@
-
-@* Will have error count input and update button for submission *@

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml
@@ -4,3 +4,6 @@
     ViewData["Title"] = "Edit packet submission";
 }
 
+@* Marvin dev: The packet submission edit view *@
+
+@* Will have error count input and update button for submission *@

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
@@ -34,41 +34,41 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
             return Partial("_Edit", PacketSubmission);
         }
 
-        public async Task<IActionResult> OnPostAsync(PacketSubmissionModel packetSubmission, [FromForm]int packetStatus)
+        public async Task<IActionResult> OnPostAsync(PacketSubmissionModel packetSubmission, [FromForm] int packetStatus)
         {
             Packet existingPacket = await GetPacketData(packetSubmission.PacketId);
 
-            if (existingPacket == null)
-                return NotFound($"Existing packet with Id of {packetSubmission.PacketId} not found");
-
-            // Update packet status
-            if (existingPacket.TryUpdateStatus((PacketStatus)packetStatus))
-            {
-                existingPacket.UpdateStatus((PacketStatus)packetStatus);
-            }
-            else
-            {
-                return NotFound($"Unable to set packet Id ${existingPacket.Id} status to: {packetStatus}");
-            }
-
-            // Update status to failed error checks when error count is saved
             if (existingPacket != null)
             {
-                Packet updatedPacket = await _packetService.UpdatePacketSubmissionErrorCount(User.Identity.Name, existingPacket, (int)packetSubmission.ErrorCount, packetSubmission.Id);
+                // Update packet status using index of packetStatus enum index
+                if (existingPacket.TryUpdateStatus((PacketStatus)packetStatus))
+                {
+                    existingPacket.UpdateStatus((PacketStatus)packetStatus);
+                }
+                else
+                {
+                    return NotFound($"Unable to set packet Id ${existingPacket.Id} status to: {packetStatus}");
+                }
 
-                // Create a packetModel to return to the index
-                PacketModel updatedPacketModel = updatedPacket.ToVM();
-                updatedPacketModel.Participation = existingPacket.Participation.ToVM();
+                if (existingPacket != null)
+                {
+                    Packet updatedPacket = await _packetService.UpdatePacketSubmissionErrorCount(User.Identity.Name, existingPacket, (int)packetSubmission.ErrorCount, packetSubmission.Id);
 
-                return Partial("_Index", updatedPacketModel);
+                    // Create a packetModel to return to the index
+                    PacketModel updatedPacketModel = updatedPacket.ToVM();
+                    updatedPacketModel.Participation = existingPacket.Participation.ToVM();
+
+                    return Partial("_Index", updatedPacketModel);
+                }
+
+                // return existing packetModel on failure to update
+                PacketModel existingPacketModel = existingPacket.ToVM();
+                existingPacketModel.Participation = existingPacket.Participation.ToVM();
+
+                return Partial("_Index", existingPacketModel);
             }
 
-            // return existing packetModel on failure to update
-            PacketModel existingPacketModel = existingPacket.ToVM();
-            existingPacketModel.Participation = existingPacket.Participation.ToVM();
-
-            return Partial("_Index", existingPacketModel);
-
+            return NotFound($"Unable to set packet Id ${packetSubmission.PacketId} status to: {(PacketStatus)packetStatus}");
         }
 
         private async Task<Packet> GetPacketData(int packetId)

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
@@ -40,16 +40,24 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
 
             // Update status to failed error checks when error count is saved
             if (existingPacket.TryUpdateStatus(PacketStatus.FailedErrorChecks))
+            {
                 existingPacket.UpdateStatus(PacketStatus.FailedErrorChecks);
 
-            Packet updatedPacket = await _packetService.UpdatePacketSubmissionErrorCount(User.Identity.Name, existingPacket, (int)packetSubmission.ErrorCount, packetSubmission.Id);
+                Packet updatedPacket = await _packetService.UpdatePacketSubmissionErrorCount(User.Identity.Name, existingPacket, (int)packetSubmission.ErrorCount, packetSubmission.Id);
 
+                // Create a packetModel to return to the index
+                PacketModel updatedPacketModel = updatedPacket.ToVM();
+                updatedPacketModel.Participation = existingPacket.Participation.ToVM();
 
-            // Create a packetModel to return to the index
-            PacketModel updatedPacketModel = updatedPacket.ToVM();
-            updatedPacket.Participation = existingPacket.Participation;
+                return Partial("_Index", updatedPacketModel);
+            }
 
-            return Partial("_Index", updatedPacket);
+            // return existing packetModel on failure to update
+            PacketModel existingPacketModel = existingPacket.ToVM();
+            existingPacketModel.Participation = existingPacket.Participation.ToVM();
+
+            return Partial("_Index", existingPacketModel);
+
         }
 
         public async Task<IActionResult> OnPostSuccessAsync(int packetId, int packetSubmissionId)
@@ -57,17 +65,24 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
             Packet existingPacket = await GetPacketData(packetId);
 
             // Update status to failed error checks when error count is saved
-            if (existingPacket.TryUpdateStatus(PacketStatus.FailedErrorChecks))
-                existingPacket.UpdateStatus(PacketStatus.FailedErrorChecks);
+            if (existingPacket.TryUpdateStatus(PacketStatus.PassedErrorChecks))
+            {
+                existingPacket.UpdateStatus(PacketStatus.PassedErrorChecks);
 
-            Packet updatedPacket = await _packetService.UpdatePacketSubmissionErrorCount(User.Identity.Name, existingPacket, 0, packetSubmisionId);
+                Packet updatedPacket = await _packetService.UpdatePacketSubmissionErrorCount(User.Identity.Name, existingPacket, 0, packetSubmissionId);
 
+                // Create a packetModel to return to the index
+                PacketModel updatedPacketModel = updatedPacket.ToVM();
+                updatedPacketModel.Participation = existingPacket.Participation.ToVM();
 
-            // Create a packetModel to return to the index
-            PacketModel updatedPacketModel = updatedPacket.ToVM();
-            updatedPacket.Participation = existingPacket.Participation;
+                return Partial("_Index", updatedPacketModel);
+            }
 
-            return Partial("_Index", updatedPacket);
+            // return existing packetModel on failure to update
+            PacketModel existingPacketModel = existingPacket.ToVM();
+            existingPacketModel.Participation = existingPacket.Participation.ToVM();
+
+            return Partial("_Index", existingPacketModel);
         }
 
         private async Task<Packet> GetPacketData(int packetId)

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
@@ -1,20 +1,72 @@
 ﻿using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using UDS.Net.Forms.Extensions;
 using UDS.Net.Forms.Models;
 using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Services;
+using UDS.Net.Services.DomainModels.Submission;
 
 namespace UDS.Net.Forms.Pages.PacketSubmissions
 {
-    public class EditModel : PacketPageModel
+    public class EditModel : PageModel
     {
-        public EditModel(IParticipationService participationService, IPacketService packetSubmissionService) : base(participationService, packetSubmissionService)
+        protected readonly IPacketService _packetService;
+        
+        PacketSubmissionModel packet { get; set; }
+
+        public EditModel(IPacketService packetService)
         {
-            //Marvin Dev: Edit page model
-            
-            //Post route for submitting error count from the packet submissions edit view
+            _packetService = packetService;
         }
+
+        public IActionResult OnGetPartial(int id)
+        {
+            packet = new PacketSubmissionModel
+            {
+                PacketId = id
+            };
+
+            return Partial("_Edit", packet);
+        }
+
+        //public async Task<IActionResult> OnPostAsync(int packetId, PacketSubmissionModel newPacketSubmission)
+        //{
+        //    var packet = await _packetService.GetById(User.Identity.Name, packetId);
+
+        //    if (packet == null)
+        //        return NotFound();
+
+        //    var participation = await _participationService.GetById(User.Identity.Name, packet.ParticipationId);
+
+        //    if (participation == null)
+        //        return NotFound();
+
+        //    Packet = packet.ToVM();
+
+        //    Packet.Participation = participation.ToVM();
+
+        //    ModelState.Clear();
+
+        //    TryValidateModel(newPacketSubmission);
+
+        //    if (!ModelState.IsValid)
+        //    {
+        //        Packet.NewPacketSubmission = newPacketSubmission;
+        //        return Partial("_Create", Packet);
+        //    }
+
+        //    packet.AddSubmission(newPacketSubmission.ToEntity()); // this ensures the packet's state is set according to business rules
+
+        //    await _packetService.Update(User.Identity.Name, packet);
+
+        //    var updatedPacket = await _packetService.GetById(User.Identity.Name, packetId); // get updated packet
+
+        //    Packet = updatedPacket.ToVM();
+        //    Packet.Participation = participation.ToVM();
+
+        //    return Partial("_Index", Packet);
+        //}
     }
 }
 

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
@@ -34,6 +34,7 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
             return Partial("_Edit", PacketSubmission);
         }
 
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> OnPostAsync(PacketSubmissionModel packetSubmission, [FromForm] int packetStatus)
         {
             Packet existingPacket = await GetPacketData(packetSubmission.PacketId);

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
@@ -11,6 +11,9 @@ namespace UDS.Net.Forms.Pages.PacketSubmissions
     {
         public EditModel(IParticipationService participationService, IPacketService packetSubmissionService) : base(participationService, packetSubmissionService)
         {
+            //Marvin Dev: Edit page model
+            
+            //Post route for submitting error count from the packet submissions edit view
         }
     }
 }

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/Edit.cshtml.cs
@@ -3,70 +3,95 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using UDS.Net.Forms.Extensions;
 using UDS.Net.Forms.Models;
-using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Services;
-using UDS.Net.Services.DomainModels.Submission;
 
 namespace UDS.Net.Forms.Pages.PacketSubmissions
 {
     public class EditModel : PageModel
     {
+        protected readonly IParticipationService _participationService;
         protected readonly IPacketService _packetService;
-        
-        PacketSubmissionModel packet { get; set; }
 
-        public EditModel(IPacketService packetService)
+        [BindProperty]
+        public int PacketSubmissionId { get; set; }
+        [BindProperty]
+        public int PacketId { get; set; }
+        [BindProperty]
+        public int? ErrorCount { get; set; }
+
+        public PacketModel? Packet { get; set; }
+
+        public EditModel(IParticipationService participationService, IPacketService packetService)
         {
+            _participationService = participationService;
             _packetService = packetService;
         }
 
-        public IActionResult OnGetPartial(int id)
-        {
-            packet = new PacketSubmissionModel
-            {
-                PacketId = id
-            };
+        // In the get we need to grab all the packet data because packet.update is how the submissions is created/modified. Packet submissions are referenced as a child of packet in the application
 
-            return Partial("_Edit", packet);
+        //packetSubmissionId will be used to target and modify the individual packet submission in the post route
+        public IActionResult OnGetPartialAsync(int packetSubmissionId, int packetId)
+        {
+            PacketSubmissionId = packetSubmissionId;
+            PacketId = packetId;
+
+            return Partial("_Edit");
         }
 
-        //public async Task<IActionResult> OnPostAsync(int packetId, PacketSubmissionModel newPacketSubmission)
-        //{
-        //    var packet = await _packetService.GetById(User.Identity.Name, packetId);
+        public async Task<IActionResult> OnPostAsync()
+        {
 
-        //    if (packet == null)
-        //        return NotFound();
+            // NOTE: need to modify and save data that was updated from existing packet. Currently, converting to page model Packet is losing data, but existing packet isn't the approppraite type for Update()
 
-        //    var participation = await _participationService.GetById(User.Identity.Name, packet.ParticipationId);
+            var existingPacket = await _packetService.GetById(User.Identity.Name, PacketId);
 
-        //    if (participation == null)
-        //        return NotFound();
+            if (existingPacket == null)
+                return NotFound();
 
-        //    Packet = packet.ToVM();
+            var participation = await _participationService.GetById(User.Identity.Name, existingPacket.ParticipationId);
 
-        //    Packet.Participation = participation.ToVM();
+            if (participation == null)
+                return NotFound();
 
-        //    ModelState.Clear();
+            Packet = existingPacket.ToVM();
 
-        //    TryValidateModel(newPacketSubmission);
+            Packet.Participation = participation.ToVM();
 
-        //    if (!ModelState.IsValid)
-        //    {
-        //        Packet.NewPacketSubmission = newPacketSubmission;
-        //        return Partial("_Create", Packet);
-        //    }
+            // Modify packet submission from list by packet submission Id
+            PacketSubmissionModel packetToEdit = Packet.PacketSubmissions.Where(p => p.Id == PacketSubmissionId).FirstOrDefault();
 
-        //    packet.AddSubmission(newPacketSubmission.ToEntity()); // this ensures the packet's state is set according to business rules
+            if (packetToEdit == null)
+                return NotFound();
 
-        //    await _packetService.Update(User.Identity.Name, packet);
+            // get index of packet submission to edit
+            int packetSubmissionEditIndex = Packet.PacketSubmissions.IndexOf(packetToEdit);
 
-        //    var updatedPacket = await _packetService.GetById(User.Identity.Name, packetId); // get updated packet
+            Packet.PacketSubmissions[packetSubmissionEditIndex].ErrorCount = ErrorCount;
 
-        //    Packet = updatedPacket.ToVM();
-        //    Packet.Participation = participation.ToVM();
 
-        //    return Partial("_Index", Packet);
-        //}
+            // Don't validate for now
+
+            //ModelState.Clear();
+
+            //TryValidateModel(newPacketSubmission);
+
+            //if (!ModelState.IsValid)
+            //{
+            //    Packet.NewPacketSubmission = newPacketSubmission;
+            //    return Partial("_Create", Packet);
+            //}
+
+            //packet.AddSubmission(newPacketSubmission.ToEntity()); // this ensures the packet's state is set according to business rules
+
+            await _packetService.Update(User.Identity.Name, existingPacket);
+
+            var updatedPacket = await _packetService.GetById(User.Identity.Name, PacketId); // get updated packet
+
+            Packet = updatedPacket.ToVM();
+            Packet.Participation = participation.ToVM();
+
+            return Partial("_Index", Packet);
+        }
     }
 }
 

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
@@ -4,23 +4,40 @@
 
 
 <turbo-frame id="EditPacketSubmission">
-    <div>
-        <form method="post" asp-page="../PacketSubmissions/Edit">
-            <h1 class="text-xl">Update packet with failed status?</h1>
-            <div class="pt-3">
-                <label class="">Errors Count</label>
-                <input asp-for="ErrorCount" type="number" min="1" class="block w-full max-w-lg rounded-md border-gray-400 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:max-w-xs sm:text-sm placeholder:text-gray-400 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" />
-                <input type="hidden" asp-for="PacketId" />
-                <input type="hidden" asp-for="Id" />
-            </div>
-            <div class="pt-3 ">
-                <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-                    Yes, Update
-                </button>
-                <a data-turbo-frame="PacketSubmissions" asp-page="../Packets/Details" asp-route-id="@Model.PacketId" class="rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600">
-                    Cancel
-                </a>
-            </div>
-        </form>
-    </div>
+    <form method="post" asp-page="../PacketSubmissions/Edit">
+        <table class="w-full text-left">
+            <thead>
+                <tr>
+                    <th class="w-1/4"></th>
+                    <th class="w-1/4"></th>
+                    <th class="w-1/4"></th>
+                    <th class="w-1/4"></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan="2">
+                        <p class="text-center">Update submission error count and set failed status?</p>
+                    </td>
+                    <td>
+                        <label class="">Errors Count</label>
+                        <input asp-for="ErrorCount" type="number" min="1" class="block w-full max-w-lg rounded-md border-gray-400 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:max-w-xs sm:text-sm placeholder:text-gray-400 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" />
+                        <input type="hidden" asp-for="PacketId" />
+                        <input type="hidden" asp-for="Id" />
+                        <input type="hidden" name="packetStatus" value="3" />
+                    </td>
+                    <td>
+                        <div class="grid grid-cols-2 justify-items-center">
+                            <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                                Update Error Count
+                            </button>
+                            <a data-turbo-frame="PacketSubmissions" asp-page="../Packets/Details" asp-route-id="@Model.PacketId" class="rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600">
+                                Cancel
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </form>
 </turbo-frame>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
@@ -1,4 +1,4 @@
-@model PacketSubmissionModel
+@model EditModel
 @{
 }
 
@@ -9,7 +9,9 @@
             <h1 class="text-xl">Update packet with failed status?</h1>
             <div class="pt-3">
                 <label class="">Errors Count</label>
-                <input class="block w-full max-w-lg rounded-md border-gray-400 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:max-w-xs sm:text-sm placeholder:text-gray-400 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" />
+                <input asp-for="ErrorCount" type="number" class="block w-full max-w-lg rounded-md border-gray-400 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:max-w-xs sm:text-sm placeholder:text-gray-400 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" />
+                <input type="hidden" asp-for="PacketId" />
+                <input type="hidden" asp-for="PacketSubmissionId" />
             </div>
             <div class="pt-3 ">
                 <button class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
@@ -1,0 +1,12 @@
+@model PacketSubmissionModel
+@{
+}
+
+
+<turbo-frame id="PacketSubmissions">
+    <form method="post" asp-page="../PacketSubmissions/Edit">
+        <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+            <h1>Update packet with failed status</h1>
+        </div>
+    </form>
+</turbo-frame>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
@@ -3,7 +3,7 @@
 }
 
 
-<turbo-frame id="PacketSubmissions">
+<turbo-frame id="EditPacketSubmission">
     <div>
         <form method="post" asp-page="../PacketSubmissions/Edit">
             <h1 class="text-xl">Update packet with failed status?</h1>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
@@ -1,4 +1,4 @@
-@model EditModel
+@model PacketSubmissionModel
 @{
 }
 
@@ -9,17 +9,17 @@
             <h1 class="text-xl">Update packet with failed status?</h1>
             <div class="pt-3">
                 <label class="">Errors Count</label>
-                <input asp-for="ErrorCount" type="number" class="block w-full max-w-lg rounded-md border-gray-400 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:max-w-xs sm:text-sm placeholder:text-gray-400 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" />
+                <input asp-for="ErrorCount" type="number" min="1" class="block w-full max-w-lg rounded-md border-gray-400 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:max-w-xs sm:text-sm placeholder:text-gray-400 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" />
                 <input type="hidden" asp-for="PacketId" />
-                <input type="hidden" asp-for="PacketSubmissionId" />
+                <input type="hidden" asp-for="Id" />
             </div>
             <div class="pt-3 ">
                 <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
                     Yes, Update
                 </button>
-                <button class="rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600">
+                <a data-turbo-frame="PacketSubmissions" asp-page="../Packets/Details" asp-route-id="@Model.PacketId" class="rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600">
                     Cancel
-                </button>
+                </a>
             </div>
         </form>
     </div>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
@@ -14,7 +14,7 @@
                 <input type="hidden" asp-for="PacketSubmissionId" />
             </div>
             <div class="pt-3 ">
-                <button class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
                     Yes, Update
                 </button>
                 <button class="rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600">

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Edit.cshtml
@@ -4,9 +4,21 @@
 
 
 <turbo-frame id="PacketSubmissions">
-    <form method="post" asp-page="../PacketSubmissions/Edit">
-        <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
-            <h1>Update packet with failed status</h1>
-        </div>
-    </form>
+    <div>
+        <form method="post" asp-page="../PacketSubmissions/Edit">
+            <h1 class="text-xl">Update packet with failed status?</h1>
+            <div class="pt-3">
+                <label class="">Errors Count</label>
+                <input class="block w-full max-w-lg rounded-md border-gray-400 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:max-w-xs sm:text-sm placeholder:text-gray-400 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none" />
+            </div>
+            <div class="pt-3 ">
+                <button class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                    Yes, Update
+                </button>
+                <button class="rounded-md bg-gray-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
 </turbo-frame>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -63,7 +63,11 @@
                                                 }
                                                 else
                                                 {
-                                                    <a asp-page="Edit" asp-route-id="@packetSubmission.Id" asp-route-errorCount="0" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</a>
+                                                    <form asp-page="../PacketSubmissions/Edit" asp-page-handler="Success" method="post">
+                                                        <input type="hidden" name="packetId" value="@Model.Id" />
+                                                        <input type="hidden" name="packetSubmissionId" value="@packetSubmission.Id" />
+                                                        <button type="submit" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</button>
+                                                    </form>
 
                                                     <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
                                                 }

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -57,7 +57,7 @@
                                         <td>
                                             <a asp-page="Edit" asp-route-id="@packetSubmission.Id" asp-route-errorCount="0" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</a>
                                             @*Marvin Dev: Errors returned button*@
-                                            <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-Id="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
+                                            <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
                                         </td>
                                     </tr>
                                 }

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -57,7 +57,7 @@
                                         <td>
                                             <a asp-page="Edit" asp-route-id="@packetSubmission.Id" asp-route-errorCount="0" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</a>
                                             @*Marvin Dev: Errors returned button*@
-                                            <a asp-page="Edit" asp-route-id="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
+                                            <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-Id="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
                                         </td>
                                     </tr>
                                 }

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -56,6 +56,7 @@
                                         </td>
                                         <td>
                                             <a asp-page="Edit" asp-route-id="@packetSubmission.Id" asp-route-errorCount="0" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</a>
+                                            @*Marvin Dev: Errors returned button*@
                                             <a asp-page="Edit" asp-route-id="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
                                         </td>
                                     </tr>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -23,30 +23,30 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach (var packetSubmission in Model.PacketSubmissions)
+                                @for (int i = 0; i < Model.PacketSubmissions.Count - 1; i++)
                                 {
                                     <tr>
                                         <td>
-                                            @packetSubmission.SubmissionDate<br />
-                                            @packetSubmission.CreatedBy
+                                            @Model.PacketSubmissions[i].SubmissionDate<br />
+                                            @Model.PacketSubmissions[i].CreatedBy
                                         </td>
                                         <td>
-                                            @if (!packetSubmission.ErrorCount.HasValue)
+                                            @if (!Model.PacketSubmissions[i].ErrorCount.HasValue)
                                             {
                                                 <a asp-page="../PacketSubmissions/Export" asp-route-packetId="@Model.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500" target="_blank">
-                                                    @(packetSubmission.GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))
+                                                    @(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))
                                                 </a>
                                             }
                                             else
                                             {
-                                                <span>@(packetSubmission.GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
+                                                <span>@(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
                                             }
                                         </td>
                                         <td>
-                                            @if (packetSubmission.ErrorCount.HasValue)
+                                            @if (Model.PacketSubmissions[i].ErrorCount.HasValue)
                                             {
                                                 @* TODO: Dispay ration of unresolved errors / errorCount. Unresolved errors are errors with a null "resolvedBy" value *@
-                                                <span>@packetSubmission.ErrorCount</span>
+                                                <span>@Model.PacketSubmissions[i].ErrorCount</span>
                                             }
                                             else
                                             {
@@ -55,7 +55,55 @@
                                         </td>
                                         <td>
                                             <div class="grid grid-cols-2 justify-items-center">
-                                                @if (packetSubmission.ErrorCount.HasValue)
+                                                @if (Model.PacketSubmissions[i].ErrorCount.HasValue)
+                                                {
+                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Success</a>
+
+                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Errors returned</a>
+                                                }
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        <turbo-frame id="EditPacketSubmission">
+                            <table class="full-text text-left">
+                                <tbody>
+                                    <tr>
+                                        @{
+                                            var recentIndex = Model.PacketSubmissions.Count() - 1;
+                                        }
+                                        <td>
+                                            @Model.PacketSubmissions[recentIndex].SubmissionDate<br />
+                                            @Model.PacketSubmissions[recentIndex].CreatedBy
+                                        </td>
+                                        <td>
+                                            @if (!Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
+                                            {
+                                                <a asp-page="../PacketSubmissions/Export" asp-route-packetId="@Model.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500" target="_blank">
+                                                    @(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))
+                                                </a>
+                                            }
+                                            else
+                                            {
+                                                <span>@(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
+                                            }
+                                        </td>
+                                        <td>
+                                            @if (Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
+                                            {
+                                                @* TODO: Dispay ration of unresolved errors / errorCount. Unresolved errors are errors with a null "resolvedBy" value *@
+                                                <span>@Model.PacketSubmissions[recentIndex].ErrorCount</span>
+                                            }
+                                            else
+                                            {
+                                                <span>Pending response from NACC</span>
+                                            }
+                                        </td>
+                                        <td>
+                                            <div class="grid grid-cols-2 justify-items-center">
+                                                @if (Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
                                                 {
                                                     <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Success</a>
 
@@ -65,22 +113,21 @@
                                                 {
                                                     <form asp-page="../PacketSubmissions/Edit" asp-page-handler="Success" method="post">
                                                         <input type="hidden" name="packetId" value="@Model.Id" />
-                                                        <input type="hidden" name="packetSubmissionId" value="@packetSubmission.Id" />
+                                                        <input type="hidden" name="packetSubmissionId" value="@Model.PacketSubmissions[recentIndex].Id" />
                                                         <button type="submit" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</button>
                                                     </form>
 
-                                                    <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
+                                                    <a data-turbo-frame="PacketSubmissionEdit" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@Model.PacketSubmissions[recentIndex].Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
                                                 }
                                             </div>
                                         </td>
                                     </tr>
-                                }
-                            </tbody>
-                        </table>
+                                </tbody>
+                            </table>
+                        </turbo-frame>
                     </div>
                 </div>
             </div>
         </div>
     }
-
 </turbo-frame>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -13,128 +13,131 @@
             <div class="mt-6 overflow-hidden border-t border-gray-100">
                 <div class="mx-auto max-w-12xl px-4 sm:px-6 lg:px-8">
                     <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
-                        <table class="w-full text-left">
-                            <thead>
-                                <tr>
-                                    <th class="w-1/4">Submission date</th>
-                                    <th class="w-1/4">Download</th>
-                                    <th class="w-1/4">Error count</th>
-                                    <th class="w-1/4"><span class="sr-only">Edit errors</span></th>
-                                </tr>
-                            </thead>
-                            <tbody class="table-fixed">
-                                @for (int i = 0; i < Model.PacketSubmissions.Count - 1; i++)
-                                {
-                                    <tr>
-                                        <td>
-                                            @Model.PacketSubmissions[i].SubmissionDate<br />
-                                            @Model.PacketSubmissions[i].CreatedBy
-                                        </td>
-                                        <td>
-                                            @if (!Model.PacketSubmissions[i].ErrorCount.HasValue)
-                                            {
-                                                <a asp-page="../PacketSubmissions/Export" asp-route-packetId="@Model.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500" target="_blank">
-                                                    @(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))
-                                                </a>
-                                            }
-                                            else
-                                            {
-                                                <span class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">@(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
-                                            }
-                                        </td>
-                                        <td>
-                                            @if (Model.PacketSubmissions[i].ErrorCount.HasValue)
-                                            {
-                                                @* TODO: Dispay ration of unresolved errors / errorCount. Unresolved errors are errors with a null "resolvedBy" value *@
-                                                <span>@Model.PacketSubmissions[i].ErrorCount</span>
-                                            }
-                                            else
-                                            {
-                                                <span>Pending response from NACC</span>
-                                            }
-                                        </td>
-                                        <td>
-                                            <div class="grid grid-cols-2 justify-items-center">
-                                                @if (Model.PacketSubmissions[i].ErrorCount.HasValue)
-                                                {
-                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Success</a>
-
-                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Errors returned</a>
-                                                }
-                                            </div>
-                                        </td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                        <turbo-frame id="EditPacketSubmission">
+                        @if(Model.PacketSubmissions.Count > 0)
+                        {
                             <table class="w-full text-left">
                                 <thead>
                                     <tr>
-                                        <th class="w-1/4"></th>
-                                        <th class="w-1/4"></th>
-                                        <th class="w-1/4"></th>
-                                        <th class="w-1/4"></th>
+                                        <th class="w-1/4">Submission date</th>
+                                        <th class="w-1/4">Download</th>
+                                        <th class="w-1/4">Error count</th>
+                                        <th class="w-1/4"><span class="sr-only">Edit errors</span></th>
                                     </tr>
                                 </thead>
-                                <tbody>
-                                    <tr>
-                                        @{
-                                            var recentIndex = Model.PacketSubmissions.Count() - 1;
-                                        }
-                                        <td>
-                                            @Model.PacketSubmissions[recentIndex].SubmissionDate<br />
-                                            @Model.PacketSubmissions[recentIndex].CreatedBy
-                                        </td>
-                                        <td>
-                                            @if (!Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
-                                            {
-                                                <a asp-page="../PacketSubmissions/Export" asp-route-packetId="@Model.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500" target="_blank">
-                                                    @(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))
-                                                </a>
-                                            }
-                                            else
-                                            {
-                                                <span class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">@(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
-                                            }
-                                        </td>
-                                        <td>
-                                            @if (Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
-                                            {
-                                                @* TODO: Dispay ration of unresolved errors / errorCount. Unresolved errors are errors with a null "resolvedBy" value *@
-                                                <span>@Model.PacketSubmissions[recentIndex].ErrorCount</span>
-                                            }
-                                            else
-                                            {
-                                                <span>Pending response from NACC</span>
-                                            }
-                                        </td>
-                                        <td>
-                                            <div class="grid grid-cols-2 justify-items-center">
-                                                @if (Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
+                                <tbody class="table-fixed">
+                                    @for (int i = 0; i < Model.PacketSubmissions.Count - 1; i++)
+                                    {
+                                        <tr>
+                                            <td>
+                                                @Model.PacketSubmissions[i].SubmissionDate<br />
+                                                @Model.PacketSubmissions[i].CreatedBy
+                                            </td>
+                                            <td>
+                                                @if (!Model.PacketSubmissions[i].ErrorCount.HasValue)
                                                 {
-                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Success</a>
-
-                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Errors returned</a>
+                                                    <a asp-page="../PacketSubmissions/Export" asp-route-packetId="@Model.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500" target="_blank">
+                                                        @(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))
+                                                    </a>
                                                 }
                                                 else
                                                 {
-                                                    <form asp-page="../PacketSubmissions/Edit" asp-page-handler="Success" method="post">
-                                                        <input type="hidden" name="ErrorCount" value="0" />
-                                                        <input type="hidden" name="PacketId" value="@Model.Id" />
-                                                        <input type="hidden" name="Id" value="@Model.PacketSubmissions[recentIndex].Id" />
-                                                        <input type="hidden" name="packetStatus" value="4" />
-                                                        <button type="submit" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</button>
-                                                    </form>
-
-                                                    <a data-turbo-frame="PacketSubmissionEdit" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@Model.PacketSubmissions[recentIndex].Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
+                                                    <span class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">@(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
                                                 }
-                                            </div>
-                                        </td>
-                                    </tr>
+                                            </td>
+                                            <td>
+                                                @if (Model.PacketSubmissions[i].ErrorCount.HasValue)
+                                                {
+                                                    @* TODO: Dispay ration of unresolved errors / errorCount. Unresolved errors are errors with a null "resolvedBy" value *@
+                                                    <span>@Model.PacketSubmissions[i].ErrorCount</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>Pending response from NACC</span>
+                                                }
+                                            </td>
+                                            <td>
+                                                <div class="grid grid-cols-2 justify-items-center">
+                                                    @if (Model.PacketSubmissions[i].ErrorCount.HasValue)
+                                                    {
+                                                        <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Success</a>
+
+                                                        <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Errors returned</a>
+                                                    }
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    }
                                 </tbody>
                             </table>
-                        </turbo-frame>
+                            <turbo-frame id="EditPacketSubmission">
+                                <table class="w-full text-left">
+                                    <thead>
+                                        <tr>
+                                            <th class="w-1/4"></th>
+                                            <th class="w-1/4"></th>
+                                            <th class="w-1/4"></th>
+                                            <th class="w-1/4"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            @{
+                                                var recentIndex = Model.PacketSubmissions.Count() - 1;
+                                            }
+                                            <td>
+                                                @Model.PacketSubmissions[recentIndex].SubmissionDate<br />
+                                                @Model.PacketSubmissions[recentIndex].CreatedBy
+                                            </td>
+                                            <td>
+                                                @if (!Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
+                                                {
+                                                    <a asp-page="../PacketSubmissions/Export" asp-route-packetId="@Model.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500" target="_blank">
+                                                        @(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))
+                                                    </a>
+                                                }
+                                                else
+                                                {
+                                                    <span class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">@(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
+                                                }
+                                            </td>
+                                            <td>
+                                                @if (Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
+                                                {
+                                                    @* TODO: Dispay ration of unresolved errors / errorCount. Unresolved errors are errors with a null "resolvedBy" value *@
+                                                    <span>@Model.PacketSubmissions[recentIndex].ErrorCount</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>Pending response from NACC</span>
+                                                }
+                                            </td>
+                                            <td>
+                                                <div class="grid grid-cols-2 justify-items-center">
+                                                    @if (Model.PacketSubmissions[recentIndex].ErrorCount.HasValue)
+                                                    {
+                                                        <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Success</a>
+
+                                                        <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Errors returned</a>
+                                                    }
+                                                    else
+                                                    {
+                                                        <form asp-page="../PacketSubmissions/Edit" asp-page-handler="Success" method="post">
+                                                            <input type="hidden" name="ErrorCount" value="0" />
+                                                            <input type="hidden" name="PacketId" value="@Model.Id" />
+                                                            <input type="hidden" name="Id" value="@Model.PacketSubmissions[recentIndex].Id" />
+                                                            <input type="hidden" name="packetStatus" value="4" />
+                                                            <button type="submit" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</button>
+                                                        </form>
+
+                                                        <a data-turbo-frame="PacketSubmissionEdit" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@Model.PacketSubmissions[recentIndex].Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
+                                                    }
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </turbo-frame>
+                        }
                     </div>
                 </div>
             </div>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -16,13 +16,13 @@
                         <table class="w-full text-left">
                             <thead>
                                 <tr>
-                                    <th>Submission date</th>
-                                    <th>Download</th>
-                                    <th>Error count</th>
-                                    <th><span class="sr-only">Edit errors</span></th>
+                                    <th class="w-1/4">Submission date</th>
+                                    <th class="w-1/4">Download</th>
+                                    <th class="w-1/4">Error count</th>
+                                    <th class="w-1/4"><span class="sr-only">Edit errors</span></th>
                                 </tr>
                             </thead>
-                            <tbody>
+                            <tbody class="table-fixed">
                                 @for (int i = 0; i < Model.PacketSubmissions.Count - 1; i++)
                                 {
                                     <tr>
@@ -39,7 +39,7 @@
                                             }
                                             else
                                             {
-                                                <span>@(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
+                                                <span class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">@(Model.PacketSubmissions[i].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
                                             }
                                         </td>
                                         <td>
@@ -68,7 +68,15 @@
                             </tbody>
                         </table>
                         <turbo-frame id="EditPacketSubmission">
-                            <table class="full-text text-left">
+                            <table class="w-full text-left">
+                                <thead>
+                                    <tr>
+                                        <th class="w-1/4"></th>
+                                        <th class="w-1/4"></th>
+                                        <th class="w-1/4"></th>
+                                        <th class="w-1/4"></th>
+                                    </tr>
+                                </thead>
                                 <tbody>
                                     <tr>
                                         @{
@@ -87,7 +95,7 @@
                                             }
                                             else
                                             {
-                                                <span>@(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
+                                                <span class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">@(Model.PacketSubmissions[recentIndex].GetFileName(Model.Participation.LegacyId, Model.VISIT_DATE))</span>
                                             }
                                         </td>
                                         <td>
@@ -112,8 +120,10 @@
                                                 else
                                                 {
                                                     <form asp-page="../PacketSubmissions/Edit" asp-page-handler="Success" method="post">
-                                                        <input type="hidden" name="packetId" value="@Model.Id" />
-                                                        <input type="hidden" name="packetSubmissionId" value="@Model.PacketSubmissions[recentIndex].Id" />
+                                                        <input type="hidden" name="ErrorCount" value="0" />
+                                                        <input type="hidden" name="PacketId" value="@Model.Id" />
+                                                        <input type="hidden" name="Id" value="@Model.PacketSubmissions[recentIndex].Id" />
+                                                        <input type="hidden" name="packetStatus" value="4" />
                                                         <button type="submit" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</button>
                                                     </form>
 

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -45,9 +45,8 @@
                                         <td>
                                             @if (packetSubmission.ErrorCount.HasValue)
                                             {
-                                                <span>@packetSubmission.Errors.Where(e => String.IsNullOrWhiteSpace(e.ResolvedBy) == false).Count()</span>
-                                                <span>&#47;</span>
-                                                <span>@packetSubmission.ErrorCount errors</span>
+                                                @* TODO: Dispay ration of unresolved errors / errorCount. Unresolved errors are errors with a null "resolvedBy" value *@
+                                                <span>@packetSubmission.ErrorCount</span>
                                             }
                                             else
                                             {
@@ -55,9 +54,20 @@
                                             }
                                         </td>
                                         <td>
-                                            <a asp-page="Edit" asp-route-id="@packetSubmission.Id" asp-route-errorCount="0" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</a>
-                                            @*Marvin Dev: Errors returned button*@
-                                            <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
+                                            <div class="grid grid-cols-2 justify-items-center">
+                                                @if (packetSubmission.ErrorCount.HasValue)
+                                                {
+                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Success</a>
+
+                                                    <a class="text-sm font-medium leading-6 text-gray-600 hover:text-gray-500">Errors returned</a>
+                                                }
+                                                else
+                                                {
+                                                    <a asp-page="Edit" asp-route-id="@packetSubmission.Id" asp-route-errorCount="0" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Success</a>
+
+                                                    <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Edit" asp-page-handler="Partial" asp-route-packetId="@Model.Id" asp-route-packetSubmissionId="@packetSubmission.Id" class="text-sm font-medium leading-6 text-indigo-600 hover:text-indigo-500">Errors returned</a>
+                                                }
+                                            </div>
                                         </td>
                                     </tr>
                                 }

--- a/src/UDS.Net.Forms/Pages/Packets/Details.cshtml
+++ b/src/UDS.Net.Forms/Pages/Packets/Details.cshtml
@@ -20,7 +20,7 @@
     <div class="lg:col-span-9 px-5 py-6">
         <div class="pb-4 pt-6 sm:pb-6">
             <div class="mx-auto flex flex-wrap items-center gap-6 px-4 sm:flex-nowrap sm:px-6 lg:px-8">
-                @if (Model.Packet.Status == PacketStatus.Finalized || Model.Packet.Status == PacketStatus.PassedErrorChecks)
+                @if (Model.Packet.Status == PacketStatus.Finalized)
                 {
                     <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Create" asp-page-handler="Partial" asp-route-packetId="@Model.Packet.Id" class="ml-auto flex items-center gap-x-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
                         <svg class="-ml-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>9.0.16</ReleaseVersion>
+		<ReleaseVersion>9.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
+++ b/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
@@ -8,7 +8,7 @@ namespace UDS.Net.Services.DomainModels.Submission
     {
         protected readonly List<PacketSubmission> _submissions = new List<PacketSubmission>();
 
-        public IReadOnlyList<PacketSubmission> Submissions => _submissions;// new List<PacketSubmission>();
+        public List<PacketSubmission> Submissions => _submissions;// new List<PacketSubmission>();
 
         public void AddSubmission(PacketSubmission submission)
         {

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -241,7 +241,6 @@ namespace UDS.Net.Services.DomainModels
             }
             else if (this.Status == PacketStatus.FailedErrorChecks)
             {
-                // when errors are attempted to be resolved status can be moved back to pending
                 if (status == PacketStatus.Pending)
                     updatePossible = true;
             }
@@ -262,9 +261,7 @@ namespace UDS.Net.Services.DomainModels
                 // Submitted forms can change to failed error checks when an error count is submitted
                 if (status == PacketStatus.FailedErrorChecks)
                     updatePossible = true;
-            }
-            else if (this.Status == PacketStatus.Submitted)
-            {
+
                 // Forms checked as success change to Passed error checks with an error count of 0
                 if (status == PacketStatus.PassedErrorChecks)
                     updatePossible = true;

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -256,7 +256,7 @@ namespace UDS.Net.Services.DomainModels
                 if (status == PacketStatus.Pending)
                     updatePossible = true;
             }
-            else if(this.Status == PacketStatus.Submitted)
+            else if (this.Status == PacketStatus.Submitted)
             {
                 // Submitted forms can change to failed error checks when an error count is submitted
                 if (status == PacketStatus.FailedErrorChecks)

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -257,6 +257,12 @@ namespace UDS.Net.Services.DomainModels
                 if (status == PacketStatus.Pending)
                     updatePossible = true;
             }
+            else if(this.Status == PacketStatus.Submitted)
+            {
+                // Submitted forms can change to failed error checks when an error count is submitted
+                if (status == PacketStatus.FailedErrorChecks)
+                    updatePossible = true;
+            }
             return updatePossible;
         }
 

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -263,6 +263,12 @@ namespace UDS.Net.Services.DomainModels
                 if (status == PacketStatus.FailedErrorChecks)
                     updatePossible = true;
             }
+            else if (this.Status == PacketStatus.Submitted)
+            {
+                // Forms checked as success change to Passed error checks with an error count of 0
+                if (status == PacketStatus.PassedErrorChecks)
+                    updatePossible = true;
+            }
             return updatePossible;
         }
 

--- a/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
@@ -154,7 +154,8 @@ namespace UDS.Net.Services.Extensions
                 CreatedAt = packetSubmission.CreatedAt,
                 ModifiedBy = packetSubmission.ModifiedBy,
                 DeletedBy = packetSubmission.DeletedBy,
-                IsDeleted = packetSubmission.IsDeleted
+                IsDeleted = packetSubmission.IsDeleted,
+                ErrorCount = packetSubmission.ErrorCount == 0 ? null : packetSubmission.ErrorCount,
             };
 
             if (packetSubmission.Errors != null)

--- a/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
+++ b/src/UDS.Net.Services/Extensions/DomainToDtoMapper.cs
@@ -155,7 +155,7 @@ namespace UDS.Net.Services.Extensions
                 ModifiedBy = packetSubmission.ModifiedBy,
                 DeletedBy = packetSubmission.DeletedBy,
                 IsDeleted = packetSubmission.IsDeleted,
-                ErrorCount = packetSubmission.ErrorCount == 0 ? null : packetSubmission.ErrorCount,
+                ErrorCount = packetSubmission.ErrorCount
             };
 
             if (packetSubmission.Errors != null)

--- a/src/UDS.Net.Services/IPacketService.cs
+++ b/src/UDS.Net.Services/IPacketService.cs
@@ -15,8 +15,7 @@ namespace UDS.Net.Services
 
         Task<int> Count(string username, List<PacketStatus> statuses);
 
-        // TODO create packet submission error methods
-
+        Task<Packet> UpdatePacketSubmissionErrorCount(string username, Packet packetToEdit, int errorCount, int packetSubmissionId);
     }
 }
 

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>9.0.16</Version>
+		<Version>9.1.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.16</ReleaseVersion>
+		<ReleaseVersion>9.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="7.0.0" />

--- a/src/UDS.Net.Web.MVC.Services/PacketService.cs
+++ b/src/UDS.Net.Web.MVC.Services/PacketService.cs
@@ -114,6 +114,21 @@ namespace UDS.Net.Web.MVC.Services
 
             throw new Exception("Packet not found");
         }
+
+        public async Task<Packet> UpdatePacketSubmissionErrorCount(string username, Packet packetToEdit, int errorCount, int packetSubmissionId)
+        {
+            PacketSubmission submissionToEdit = packetToEdit.Submissions.Where(p => p.Id == packetSubmissionId).FirstOrDefault();
+
+            if (submissionToEdit == null)
+                throw new Exception("Packet submission not found");
+
+            // get index of packet submission to edit
+            int submissionEditIndex = packetToEdit.Submissions.IndexOf(submissionToEdit);
+
+            packetToEdit.Submissions[submissionEditIndex].ErrorCount = errorCount;
+
+            return await Update(username, packetToEdit);
+        }
     }
 }
 

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>9.0.16</Version>
+		<Version>9.1.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>9.0.16</ReleaseVersion>
+		<ReleaseVersion>9.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>9.0.16</ReleaseVersion>
+		<ReleaseVersion>9.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves: #306 

Add in packet submission errors returned and success options to the packet submission UI. Early stage functionality, and will most likely undergo some further adjustments as continue to use the feature.

![image](https://github.com/user-attachments/assets/d819133a-fdd0-457b-8c9f-d9d4e67e154d)


## Packet Submission flow

### Getting a packet to the success or errors returned step
1 -  A packet will begin in the **Pending** state until a packet has all the required forms completed
2 - Upon finalizing all required forms the packet can be finalized from visit details view (viewing all the forms in a packet). This will set the packet to the **Finalized** state
3 - Once a packet is in the submitted state, it will appear in the packet submissions details for a packet. Click view for the packet you wish to see and from here you can create a new packet submission for that packet, setting the packet to the **Submitted** state
4 - Once a packet submission is created, you can select "Success" or "Uplaod errors" depending on what was returned from the NACC upload

### 5 - This step will differ depending on if you have errors returned or not

#### packet submission success
5a - If there were no errors returned, select "Success" to automatically set the submission to have 0 errors and change the packet status to "Passed error checks". From here, if you need to make another submission, you will need to go back to the visit and make an edit within a form in the packet, which will allow you to refinalize the packet, setting it back to the **Finalized** state. In the finalized state, you can create another submission and then mark as "Success" or "errors returned". 

#### Packet submission errors returned
5b - If there were errors, you can state the error count by selecting "Errors returned" in the packet submission view which will then display the error count input within the table

5b2 - Selecting "update error count" will set the error count for the packetsubmission and disable the buttons for further interaction. This will set the packet status to "Failed error checks" and allow you to go back and refanlize the packet

![image](https://github.com/user-attachments/assets/0f16273d-8a0a-44cc-99cc-27385a19b805)
> This graph does not account for frozen packets 

## Feature checklist
- [x] Packet submission "success" flow sets error count to 0 and changes packet status to "PassedErrorChecks"
- [x] packet submission "errors returned" flow sets error count to user input and changes packet status to "FailedErrorChecks"
- [ ] ~~packets with "FailedErrorChecks" status can be refinalized in the packet details view~~
- [ ] ~~packets with "PassedErrorChecks" status can be refinalized in the packet details view~~
- [ ] input for Errors returned must be > 0 to be a valid input 
- [x] using the cancel button on the errors returned input will return the user to the packet submissions index view