### PR TITLE
IMAGINGDX Option 2 Label Changed

### DIFF
--- a/src/UDS.Net.Forms/Pages/UDS4/D1b.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/D1b.cshtml.cs
@@ -48,7 +48,7 @@ namespace UDS.Net.Forms.Pages.UDS4
         {
             new RadioListItem("No (SKIP TO QUESTION 8)", "0"),
             new RadioListItem("Yes, only PET/SPECT imaging was used (CONTINUE TO QUESTION 6, and SKIP QUESTIONS 7 – 7a3f)", "1"),
-            new RadioListItem("Yes, only MR imaging was used (SKIP TO QUESTION 7)", "2"),
+            new RadioListItem("Yes, only MR/CT imaging was used (SKIP TO QUESTION 7)", "2"),
             new RadioListItem("Yes, both PET/SPECT and MR imaging were used", "3")
         };
 


### PR DESCRIPTION
Fixes #470 

- [x] Label for Option 2 now reads:  "Yes, only MR/CT imaging was used (SKIP TO QUESTION 7)”

<img width="1105" height="211" alt="IMAGINGDX" src="https://github.com/user-attachments/assets/af8bc62c-581f-44de-bcb2-1eaf014ae42a" />
