### PR TITLE
add regex annotation and update view

### DIFF
--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -483,7 +483,7 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? ADISTATE { get; set; }
 
         [Display(Name = "ADI national percentile")]
-        [RegularExpression("^([1-9]|10|88[4-7])$", ErrorMessage = "Valid range is 1-10 or 884-887")]
+        [RegularExpression("^(100|[1-9][0-9]?|88[4-7])$", ErrorMessage = "Valid range is 1-100 or 884-887")]
         public int? ADINAT { get; set; }
 
         [Display(Name = "Participant's primary occupation throughout their working life")]

--- a/src/UDS.Net.Forms/Models/UDS4/A1.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A1.cs
@@ -479,11 +479,11 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? MEMTEN { get; set; }
 
         [Display(Name = "ADI state-only decile")]
-        [Range(1, 10)]
+        [RegularExpression("^([1-9]|10|88[4-7])$", ErrorMessage = "Valid range is 1-10 or 884-887")]
         public int? ADISTATE { get; set; }
 
         [Display(Name = "ADI national percentile")]
-        [Range(1, 100)]
+        [RegularExpression("^([1-9]|10|88[4-7])$", ErrorMessage = "Valid range is 1-10 or 884-887")]
         public int? ADINAT { get; set; }
 
         [Display(Name = "Participant's primary occupation throughout their working life")]

--- a/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A1.cshtml
@@ -1084,7 +1084,7 @@
                     <input asp-for="@Model.A1.ADISTATE" />
                 </div>
                 <p class="text-gray-400">
-                    <i>(If unknown, leave blank)</i>
+                    <i>(If unknown, leave blank. For special codes, enter 884 for "PH", 885 for "GQ", 886 for "PH-GQ", and 887 for "QDI".)</i>
                 </p>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.A1.ADISTATE"></span>
             </div>
@@ -1097,7 +1097,7 @@
                 <div class="mt-2 w-20">
                     <input asp-for="@Model.A1.ADINAT" />
                 </div>
-                <p class="text-gray-400"><i>(If unknown, leave blank)</i></p>
+                <p class="text-gray-400"><i>(If unknown, leave blank. For special codes, enter 884 for "PH", 885 for "GQ", 886 for "PH-GQ", and 887 for "QDI".)</i></p>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="@Model.A1.ADINAT"></span>
             </div>
         </div>


### PR DESCRIPTION
Resolves #466 

This PR adds a REGEX pattern to "ADISTATE"  to only accept the values of 1-10 & 884-887 and "ADINAT" to accept the values 1-100 & 884-887. User instructions have also been updated to display the valid range

Example of correct fail state:
<img width="1459" height="327" alt="image" src="https://github.com/user-attachments/assets/a7ee15dd-49a1-4687-b247-019db9cc341d" />


Example of valid input:
<img width="1424" height="272" alt="image" src="https://github.com/user-attachments/assets/3972726c-e6c6-4b22-b789-95bc6a3dcbea" />
