### PR TITLE
Form D1A OTHANXDX UI Bug

### DIFF
--- a/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
+++ b/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
@@ -43,7 +43,10 @@ function setAffects(targets) {
     });
   });
 }
-function toggleAffects(targets, isSelected) {
+function toggleAffects(targets, isSelected, depth = 0) {
+    const MAX_DEPTH = 4;
+    if (depth > MAX_DEPTH) return;
+
     $.each(targets, function (index, target) {
         let element = $(`[name="${target}"]`);
 
@@ -60,7 +63,7 @@ function toggleAffects(targets, isSelected) {
 
                 let childTargets = element.data("affectsToggleTargets");
                 if (childTargets) {
-                    toggleAffects(childTargets, false);
+                    toggleAffects(childTargets, false, depth + 1);
                 }
             }
         }

--- a/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
+++ b/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
@@ -44,11 +44,28 @@ function setAffects(targets) {
   });
 }
 function toggleAffects(targets, isSelected) {
-  $.each(targets, function (index, target) {
-    // console.log(target + " disabled to " + !isSelected);
-    setAffect(target, "disabled", !isSelected);
-  });
+    $.each(targets, function (index, target) {
+        let element = $(`[name="${target}"]`);
+
+        if (element.length) {
+            setAffect(target, "disabled", !isSelected);
+
+            if (!isSelected) {
+                if (element.is(":checkbox") || element.is(":radio")) {
+                    element.prop("checked", false);
+                } else {
+                    element.val("");
+                }
+
+                let childTargets = element.data("affectsToggleTargets");
+                if (childTargets) {
+                    toggleAffects(childTargets, false);
+                }
+            }
+        }
+    });
 }
+
 function compareRange(low, high, targets, value) {
   if (value === "") {
     $.each(targets, function (index, behavior) {

--- a/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
+++ b/src/UDS.Net.Forms/wwwroot/js/jquery.unobtrusive.custom_validation.js
@@ -53,7 +53,8 @@ function toggleAffects(targets, isSelected) {
             if (!isSelected) {
                 if (element.is(":checkbox") || element.is(":radio")) {
                     element.prop("checked", false);
-                } else {
+                }
+                else {
                     element.val("");
                 }
 


### PR DESCRIPTION
Resolves #510 

## Form D1A OTHANXDX UI Bug

Update JS to disable OTHANXDX input

<img width="1345" height="437" alt="image" src="https://github.com/user-attachments/assets/cd7993df-cece-44ce-9361-a84694a27eb1" />
<img width="1342" height="429" alt="image" src="https://github.com/user-attachments/assets/c4ebb5b7-c8b7-4c2f-8195-b0e0006515cf" />

### Review Checklist
1. Check question 14 ANXIET
2. Check question 14e OTHANXD
3. OTHANXDX is now correctly enabled
4. Uncheck question 14 ANXIET
- [ ] OTHANXDX should now be correctly disabled
- [ ] Added Max Recursion Depth
<img width="396" height="57" alt="image" src="https://github.com/user-attachments/assets/7ed23c28-de5d-43b6-a4a2-068800f6c725" />
