### PR TITLE
A5D2 APNEA enhanced validation

### DIFF
--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>13.0.10</ReleaseVersion>
+		<ReleaseVersion>13.0.11</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A5D2.cs
@@ -324,11 +324,11 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? APNEA { get; set; }
         [Display(Name = "Typical use of breathing machine (e.g. CPAP) at night over the past 12 months")]
         [RegularExpression("^([0-2]|9)$", ErrorMessage = "Valid range is 0-2 or 9")]
-        [RequiredIfRange(nameof(APNEA), 1, 2, ErrorMessage = "Please specify.")]
+        [RequiredIf(nameof(APNEA), "1", ErrorMessage = "Response required")]
         public int? CPAP { get; set; }
         [Display(Name = "Typical use of an oral device for sleep apnea at night over the past 12 months?")]
         [RegularExpression("^([0-2]|9)$", ErrorMessage = "Valid range is 0-2 or 9")]
-        [RequiredIfRange(nameof(APNEA), 1, 2, ErrorMessage = "Please specify.")]
+        [RequiredIf(nameof(APNEA), "1", ErrorMessage = "Response required")]
         public int? APNEAORAL { get; set; }
         [Display(Name = "REM sleep behavior disorder")]
         [RegularExpression("^([0-2]|9)$", ErrorMessage = "Valid range is 0-2 or 9")]

--- a/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A5D2.cshtml.cs
@@ -907,8 +907,8 @@ public class A5D2Model : FormPageModel
             {
                  PropertyAttributes = new List<UIPropertyAttributes>
                      {
-                         new UIEnableAttribute("A5D2.CPAP"),
-                         new UIEnableAttribute("A5D2.APNEAORAL")
+                         new UIDisableAttribute("A5D2.CPAP"),
+                         new UIDisableAttribute("A5D2.APNEAORAL")
                      }
             }
          },

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>13.0.10</Version>
+		<Version>13.0.11</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.10</ReleaseVersion>
+		<ReleaseVersion>13.0.11</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>13.0.10</ReleaseVersion>
+		<ReleaseVersion>13.0.11</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>13.0.10</Version>
+		<Version>13.0.11</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.10</ReleaseVersion>
+		<ReleaseVersion>13.0.11</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="8.0.2" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>13.0.10</Version>
+		<Version>13.0.11</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.10</ReleaseVersion>
+		<ReleaseVersion>13.0.11</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>13.0.10</ReleaseVersion>
+		<ReleaseVersion>13.0.11</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves #515 

When APNEA has a value of 2, both CPAP and APNEAORAL are both disabled. CPAP and APNEAORAL now only require a response when APNEA has a value of 1

<img width="1390" height="409" alt="image" src="https://github.com/user-attachments/assets/b350a985-8194-4980-a106-44d8da5de80e" />


