### PR TITLE
Convert INRELTO check to alert rather than validation

### DIFF
--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<ReleaseVersion>13.0.17</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>13.0.16</ReleaseVersion>
+		<ReleaseVersion>13.0.17</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms/Models/UDS4/A2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/A2.cs
@@ -22,24 +22,6 @@ namespace UDS.Net.Forms.Models.UDS4
         public int? INLIVWTH { get; set; }
         [Display(Name = "What is the primary mode of contact with the participant?")]
         [RequiredIf(nameof(INLIVWTH), "0", ErrorMessage = "Response to primary mode of contact required")]
-
-        [NotMapped]
-        [RequiredOnFinalized(ErrorMessage = "IF Q1. INRELTO = 1, then Q3. INLIVWTH should not equal 0")]
-        public bool? InlivwthInvalid
-        {
-            get
-            {
-                if (INRELTO == 1 && INLIVWTH == 0)
-                {
-                    return null;
-                }
-
-                return true;
-            }
-        }
-
-        [Display(Name = "What is the primary mode of contact with the participant?")]
-        [RequiredIf(nameof(INLIVWTH), "0", ErrorMessage = "Response to primary mode of contact required")]
         public int? INCNTMOD { get; set; }
         [Display(Name = "Primary mode of contact with the participant - Other (specify)")]
         [MaxLength(60)]

--- a/src/UDS.Net.Forms/Pages/UDS4/A2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/A2.cshtml
@@ -43,7 +43,6 @@
                 <p class="text-sm text-gray-500" asp-description-for="A2.INLIVWTH"></p>
                 <radio-button-group id="A2_INLIVWTHOptions" for="@Model.A2.INLIVWTH" items="Model.INLIVWTHListItems" ui-behaviors="Model.INLIVWTHOptionsUIBehavior"></radio-button-group>
                 <span class="mt-2 text-sm text-red-600" asp-validation-for="A2.INLIVWTH"></span>
-                <span class="mt-2 text-sm text-red-600" asp-validation-for="A2.InlivwthInvalid"></span>
             </div>
         </div>
 

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>13.0.16</Version>
+		<Version>13.0.17</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.16</ReleaseVersion>
+		<ReleaseVersion>13.0.17</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>13.0.16</ReleaseVersion>
+		<ReleaseVersion>13.0.17</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/src/UDS.Net.Services/DomainModels/Visit.cs
+++ b/src/UDS.Net.Services/DomainModels/Visit.cs
@@ -401,13 +401,20 @@ namespace UDS.Net.Services.DomainModels
             List<VisitValidationResult> results = new List<VisitValidationResult>();
 
             var a1 = (A1FormFields)this.Forms.Where(f => f.Kind == "A1").Select(f => f.Fields).FirstOrDefault();
+            var a2 = (A2FormFields)this.Forms.Where(f => f.Kind == "A2").Select(f => f.Fields).FirstOrDefault();
             var a5d2 = (A5D2FormFields)this.Forms.Where(f => f.Kind == "A5D2").Select(f => f.Fields).FirstOrDefault();
             var b5 = (B5FormFields)this.Forms.Where(f => f.Kind == "B5").Select(f => f.Fields).FirstOrDefault();
             var b9 = (B9FormFields)this.Forms.Where(f => f.Kind == "B9").Select(f => f.Fields).FirstOrDefault();
             var d1a = (D1aFormFields)this.Forms.Where(f => f.Kind == "D1a").Select(f => f.Fields).FirstOrDefault();
 
-            if (a1 != null && a5d2 != null && b5 != null && b9 != null && d1a != null)
+            if (a1 != null && a2 != null && a5d2 != null && b5 != null && b9 != null && d1a != null)
             {
+                if (a2.INRELTO.HasValue && a2.INRELTO.Value == 1 && a2.INLIVWTH.HasValue && a2.INLIVWTH == 0)
+                {
+                    results.Add(new VisitValidationResult(
+                        $"A2 if q1. INRELTO = 1 (spouse, partner, or companion), then A2 q3. INLIVWTH should not equal 0 (does not live with co-participant).",
+                        new[] { nameof(a2.INRELTO), nameof(a2.INLIVWTH) }));
+                }
                 if (b5.ANX.HasValue)
                 {
                     if (b5.ANX == 0)
@@ -415,7 +422,7 @@ namespace UDS.Net.Services.DomainModels
                         if (a5d2.ANXIETY.HasValue && a5d2.ANXIETY != 0)
                         {
                             results.Add(new VisitValidationResult(
-                                $"if q6a. anx (anxiety) = 0 (no), then form a5d2, q6d. anxiety (anxiety disorder) should not equal 1 (active).",
+                                $"B5 if q6a. anx (anxiety) = 0 (no), then form A5D2, q6d. anxiety (anxiety disorder) should not equal 1 (active).",
                                 new[] { nameof(b5.ANX), nameof(a5d2.ANXIETY) }));
                         }
                     }
@@ -424,20 +431,20 @@ namespace UDS.Net.Services.DomainModels
                         if (a5d2.ANXIETY.HasValue && a5d2.ANXIETY != 1)
                         {
                             results.Add(new VisitValidationResult(
-                                $"B5 if q6a. anx (anxiety) = 1 (yes), then form a5d2, q6d. anxiety (anxiety disorder) should equal 1 (recent/active).",
+                                $"B5 if q6a. anx (anxiety) = 1 (yes), then form A5D2, q6d. anxiety (anxiety disorder) should equal 1 (recent/active).",
                                 new[] { nameof(b5.ANX), nameof(a5d2.ANXIETY) }));
                         }
                         if (b9.BEANX.HasValue && b9.BEANX != 1)
                         {
                             results.Add(new VisitValidationResult(
-                                $"if q6a. anx (anxiety) = 1 (yes), then form b9, q12c. beanx (anxiety) should equal 1 (yes).",
-                                new[] { nameof(b5.ANX), nameof(a5d2.ANXIETY) }));
+                                $"B5 if q6a. anx (anxiety) = 1 (yes), then form B9, q12c. beanx (anxiety) should equal 1 (yes).",
+                                new[] { nameof(b5.ANX), nameof(b9.BEANX) }));
                         }
                         if (d1a.ANXIET.HasValue && d1a.ANXIET != true)
                         {
                             results.Add(new VisitValidationResult(
-                                $"if q6a. anx (anxiety) = 1 (yes), then form d1a, q14. anxiet (anxiety disorder (present)) should equal 1 (present).",
-                                new[] { nameof(b5.ANX), nameof(a5d2.ANXIETY) }));
+                                $"B5 if q6a. anx (anxiety) = 1 (yes), then form D1a, q14. anxiet (anxiety disorder (present)) should equal 1 (present).",
+                                new[] { nameof(b5.ANX), nameof(d1a.ANXIET) }));
                         }
                     }
                 }

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>13.0.16</Version>
+		<Version>13.0.17</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.16</ReleaseVersion>
+		<ReleaseVersion>13.0.17</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="8.0.2" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>13.0.16</Version>
+		<Version>13.0.17</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.16</ReleaseVersion>
+		<ReleaseVersion>13.0.17</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>13.0.16</ReleaseVersion>
+		<ReleaseVersion>13.0.17</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.sln
+++ b/src/UDS.Net.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Web.MVC", "UDS.Net.Web.MVC\UDS.Net.Web.MVC.csproj", "{99F6A944-AD72-42F0-BBB1-887449A2C8E1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Forms", "UDS.Net.Forms\UDS.Net.Forms.csproj", "{A1A16BC1-B30D-41DE-AD48-471EC278B8C7}"
 EndProject
@@ -15,9 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Web.MVC.Services", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDS.Net.Services.Test", "UDS.Net.Services.Test\UDS.Net.Services.Test.csproj", "{332BFB18-1431-4572-BE96-757D0221FBCE}"
 EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{F99AEBDD-D7EA-40C9-8DDC-AE13BCCC02DC}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDS.Net.Forms.Tests.Runtime", "UDS.Net.Forms.Tests.Runtime\UDS.Net.Forms.Tests.Runtime.csproj", "{35D9C0B3-CE26-47E8-A054-2AB74F0E47FB}"
+EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "docker-compose", "docker-compose.dcproj", "{C017A3F4-7569-4C67-B00A-F6B791972237}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -65,6 +65,6 @@ Global
 		SolutionGuid = {3268D734-1592-4E39-88A2-3A53468CC430}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 12.1.4
+		version = 13.0.17
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
We incorrectly interpreted the specifications from NACC's August changelog and implemented #498. This PR adjusts so that the rule is an alert rather than a blocking error.