### PR TITLE
Add UDSVERTI validation

### DIFF
--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -535,6 +535,26 @@ namespace UDS.Net.Forms.Models.UDS4
         [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Provide count of non-F/L words and rule violation errors.")]
         public int? UDSVERTI { get; set; }
 
+        //If UDSVERNF and UDSVERLN are both valid values, then UDSVERTI must = UDSVERNF + UDSVERLN
+        //Both visit types
+        [NotMapped]
+        [RequiredOnFinalized(ErrorMessage = "If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.")]
+        public bool? UDSVERTIValidation
+        {
+            get
+            {
+                if ((UDSVERNF.HasValue && UDSVERNF <= 15) && (UDSVERLN.HasValue && UDSVERLN.Value <= 15))
+                {
+                    if (UDSVERNF + UDSVERLN != UDSVERTI)
+                    {
+                        return null;
+                    }
+                }
+
+                return true;
+            }
+        }
+
         #endregion
 
         [Display(Name = "Per the clinician (e.g., neuropsychologist, behavioral neurologist, or other suitably qualified clinician), based on the UDS neuropsychological examination, the participants cognitive status is deemed")]

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -538,7 +538,7 @@ namespace UDS.Net.Forms.Models.UDS4
         //If UDSVERNF and UDSVERLN are both valid values, then UDSVERTI must = UDSVERNF + UDSVERLN
         //Both visit types
         [NotMapped]
-        [RequiredOnFinalized(ErrorMessage = "If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.")]
+        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.")]
         public bool? UDSVERTIValidation
         {
             get

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -850,7 +850,6 @@
                         <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERFN"></p>
                     </div>
                     <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFN"></span>
-
                 </div>
 
                 <div class="@rowCSS">
@@ -942,7 +941,10 @@
                         </div>
                         <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTI"></p>
                     </div>
-                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                    <div>
+                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTIValidation"></span>
+                    </div>
                 </div>
                 <div class="subcounterreset">
                     <div class="@rowCSS sm:grid sm:grid-cols-3 sm:items-start sm:gap-4">

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -942,8 +942,12 @@
                         <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTI"></p>
                     </div>
                     <div>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTIValidation"></span>
+                        <div>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                        </div>
+                        <div>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTIValidation"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="subcounterreset">

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
@@ -1177,7 +1177,10 @@
                         </div>
                         <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTI"></p>
                     </div>
-                    <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                    <div>
+                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTIValidation"></span>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
@@ -1178,8 +1178,12 @@
                         <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTI"></p>
                     </div>
                     <div>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTIValidation"></span>
+                        <div>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                        </div>
+                        <div>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTIValidation"></span>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Resolves: #536 

### Add validation for UDSVERTI
Add validation for Question 11i UDSVERTI. When UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum.

**UDSVERNF, UDSVERLN, and UDSVERTI questions are on BOTH the in-person and telephone forms**

### Task List (apply for both in-person and telephone views)
- [ ] If UDSVERNF and UDSVERLN have values of 0 - 15, then UDSVERTI must be the sum of UDSVERNF + UDSVERLN
- [ ] If either UDSVERNF and UDSVERLN do not have a value, then validation does not run
- [ ] Validation error message appears on the right-hand column next to the input, following the established validation message location for the section
- [ ] Form saves properly when validation is satisfied