### PR TITLE
Address packet submission bugs

### DIFF
--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>13.0.23</ReleaseVersion>
+		<ReleaseVersion>13.0.24</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>13.0.19</ReleaseVersion>
+		<ReleaseVersion>13.0.20-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>13.0.23</ReleaseVersion>
+		<ReleaseVersion>13.0.24</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>13.0.19</ReleaseVersion>
+		<ReleaseVersion>13.0.20-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -8,13 +8,6 @@
     @if (Model.Participation != null && Model.PacketSubmissions != null)
     {
         <div class="space-y-16 py-16 xl:space-y-20">
-            <div class="mx-auto max-w-12xl px-4 sm:px-6 lg:px-8 mb-6 flex justify-end">
-                <a asp-page="/Visits/Details"
-                   asp-route-id="@Model.Id"
-                   class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-600 transition">
-                    View Visit
-                </a>
-            </div>
             <div class="mx-auto max-w-12xl px-4 sm:px-6 lg:px-8">
                 <h2 class="mx-auto max-w-2xl text-base font-semibold leading-6 text-gray-900 lg:mx-0 lg:max-w-none">Packet submissions</h2>
                 <p class="mt-2 text-sm text-gray-700">A new submission may only be created after all errors have been resolved from previous submission and packet re-finalized.</p>

--- a/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
+++ b/src/UDS.Net.Forms/Pages/PacketSubmissions/_Index.cshtml
@@ -10,7 +10,7 @@
         <div class="space-y-16 py-16 xl:space-y-20">
             <div class="mx-auto max-w-12xl px-4 sm:px-6 lg:px-8 mb-6 flex justify-end">
                 <a asp-page="/Visits/Details"
-                   asp-route-id="@Model.Participation.Id"
+                   asp-route-id="@Model.Id"
                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-600 transition">
                     View Visit
                 </a>

--- a/src/UDS.Net.Forms/Pages/Packets/Details.cshtml
+++ b/src/UDS.Net.Forms/Pages/Packets/Details.cshtml
@@ -20,9 +20,14 @@
     <div class="lg:col-span-9 px-5 py-6">
         <div class="pb-4 pt-6 sm:pb-6">
             <div class="mx-auto flex flex-wrap items-center gap-6 px-4 sm:flex-nowrap sm:px-6 lg:px-8">
+                <a asp-page="/Visits/Details"
+                   asp-route-id="@Model.Packet.Id"
+                   class="ml-auto inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-600 transition">
+                    View Visit
+                </a>
                 @if (Model.Packet.Status == PacketStatus.Finalized)
                 {
-                    <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Create" asp-page-handler="Partial" asp-route-packetId="@Model.Packet.Id" class="ml-auto flex items-center gap-x-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                    <a data-turbo-frame="PacketSubmissions" asp-page="../PacketSubmissions/Create" asp-page-handler="Partial" asp-route-packetId="@Model.Packet.Id" class="flex items-center gap-x-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
                         <svg class="-ml-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                             <path d="M10.75 6.75a.75.75 0 00-1.5 0v2.5h-2.5a.75.75 0 000 1.5h2.5v2.5a.75.75 0 001.5 0v-2.5h2.5a.75.75 0 000-1.5h-2.5v-2.5z"></path>
                         </svg>
@@ -31,7 +36,7 @@
                 }
                 else
                 {
-                    <button disabled class="ml-auto bg-gray-300 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm">
+                    <button disabled class="bg-gray-300 inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm">
                         <svg class="-ml-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                             <path d="M10.75 6.75a.75.75 0 00-1.5 0v2.5h-2.5a.75.75 0 000 1.5h2.5v2.5a.75.75 0 001.5 0v-2.5h2.5a.75.75 0 000-1.5h-2.5v-2.5z"></path>
                         </svg>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>13.0.23</Version>
+		<Version>13.0.24</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.23</ReleaseVersion>
+		<ReleaseVersion>13.0.24</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>13.0.19</Version>
+		<Version>13.0.20-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.19</ReleaseVersion>
+		<ReleaseVersion>13.0.20-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>13.0.23</ReleaseVersion>
+		<ReleaseVersion>13.0.24</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>13.0.19</ReleaseVersion>
+		<ReleaseVersion>13.0.20-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
+++ b/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
@@ -20,11 +20,14 @@ namespace UDS.Net.Services.DomainModels.Submission
                 else if (this._submissions != null)
                 {
                     int unresolvedCount = 0;
-                    foreach (var submisson in this._submissions)
+                    foreach (var submission in this._submissions)
                     {
-                        foreach (var error in submisson.Errors)
-                            if (String.IsNullOrWhiteSpace(error.ResolvedBy))
-                                unresolvedCount++;
+                        if(submission.Errors != null)
+                        {
+                            foreach (var error in submission.Errors)
+                                if (String.IsNullOrWhiteSpace(error.ResolvedBy))
+                                    unresolvedCount++;
+                        }
                     }
                     return unresolvedCount;
                 }

--- a/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
+++ b/src/UDS.Net.Services/DomainModels/Submission/Packet.cs
@@ -22,7 +22,7 @@ namespace UDS.Net.Services.DomainModels.Submission
                     int unresolvedCount = 0;
                     foreach (var submission in this._submissions)
                     {
-                        if(submission.Errors != null)
+                        if (submission.Errors != null)
                         {
                             foreach (var error in submission.Errors)
                                 if (String.IsNullOrWhiteSpace(error.ResolvedBy))

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>13.0.23</Version>
+		<Version>13.0.24</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.23</ReleaseVersion>
+		<ReleaseVersion>13.0.24</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="8.0.2" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>13.0.19</Version>
+		<Version>13.0.20-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.19</ReleaseVersion>
+		<ReleaseVersion>13.0.20-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="8.0.2" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>13.0.19</Version>
+		<Version>13.0.20-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.19</ReleaseVersion>
+		<ReleaseVersion>13.0.20-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>13.0.23</Version>
+		<Version>13.0.24</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>13.0.23</ReleaseVersion>
+		<ReleaseVersion>13.0.24</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>13.0.23</ReleaseVersion>
+		<ReleaseVersion>13.0.24</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>13.0.19</ReleaseVersion>
+		<ReleaseVersion>13.0.20-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves: #550 

This PR tackles 3 different tasks
- Address the packet submission "success" link bug
  - clicking the success link caused an error due to the `packet.errors` object being NULL when no errors are submitted. The code now has a NULL check.
- Address the packet submission "View visit" button bug
  - The view visit button was causing an error due to the partial providing participation id rather than the visit id
- Move the "view visit" button in packet submissions 
  - The "view visit" button is now in line with the "+ new packet submission" button

## Task List:
### Packet submission success
- [ ] When viewing a submitted packet in the packet submission view, selecting the "success" link will no longer result in an error
### Packet submission View visit
- [ ] The "view visit" will not result in an error on the uds.web public application
- [ ] The "view visit" will no longer result in an error on the uds4 - local application
  - Running the package version `13.0.20-preview.1` will allow you to test the uds4 - local application
### Reposition the "view visit" button 
- [ ] "View visit" button on packet submissions is now in line with the "+ new packet submission" button