### PR TITLE
Dependency updates

### DIFF
--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -21,8 +21,8 @@
 	<ItemGroup>
 		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.6" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
-		<PackageReference Include="UDS.Net.API.Entities" Version="10.1.0-preview.2" />
-		<PackageReference Include="UDS.Net.API.Extensions" Version="10.1.0-preview.2" />
-		<PackageReference Include="UDS.Net.Dto" Version="10.1.0-preview.2" />
+		<PackageReference Include="UDS.Net.API.Entities" Version="10.1.0" />
+		<PackageReference Include="UDS.Net.API.Extensions" Version="10.1.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="10.1.0" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -13,6 +13,6 @@
 		<ReleaseVersion>15.1.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="UDS.Net.Dto" Version="10.1.0-preview.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="10.1.0" />
 	</ItemGroup>
 </Project>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -15,8 +15,8 @@
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="UDS.Net.Dto" Version="10.1.0-preview.2" />
-		<PackageReference Include="UDS.Net.API.Client" Version="10.1.0-preview.2" />
+		<PackageReference Include="UDS.Net.Dto" Version="10.1.0" />
+		<PackageReference Include="UDS.Net.API.Client" Version="10.1.0" />
 		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.6" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.6" />
 	</ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -20,8 +20,8 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
-		<PackageReference Include="UDS.Net.API.Client" Version="10.1.0-preview.2" />
-		<PackageReference Include="UDS.Net.Dto" Version="10.1.0-preview.2" />
+		<PackageReference Include="UDS.Net.API.Client" Version="10.1.0" />
+		<PackageReference Include="UDS.Net.Dto" Version="10.1.0" />
 		<PackageReference Include="rxNorm.Net.Api.Wrapper" Version="1.0.6" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
Resolves #597 

This PR updates the UDS API dependency to include the new visit service method added by https://github.com/UK-SBCoA/uniform-data-set-dotnet-api/pull/111

I've also gone ahead and hooked up the VisitService class and interface. Everything should good for any developer that would like to use the new service method!