### PR TITLE
A4a autofill

### DIFF
--- a/src/UDS.Net.Forms.Tests.Runtime/Services/VisitService.cs
+++ b/src/UDS.Net.Forms.Tests.Runtime/Services/VisitService.cs
@@ -452,6 +452,7 @@ namespace UDS.Net.Forms.Tests.Runtime.Services
         {
             var packet = await _context.Packets
                 .Include(v => v.A3)
+                .Include(v => v.A4a)
                 .Include(v => v.A5D2)
                 .Include(v => v.B9)
                 .Where(v => v.ParticipationId == participationId && v.VISITNUM == visitNumber)
@@ -466,6 +467,11 @@ namespace UDS.Net.Forms.Tests.Runtime.Services
             {
                 var a3 = packet.A3.Convert(packet.Id, username);
                 forms.Add(a3);
+            }
+            if (packet.A4a != null)
+            {
+                var a4a = packet.A4a.Convert(packet.Id, username);
+                forms.Add(a4a);
             }
             if (packet.A5D2 != null)
             {

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>16.2.11</ReleaseVersion>
+		<ReleaseVersion>16.2.12</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests/A4aTests.cs
+++ b/src/UDS.Net.Forms.Tests/A4aTests.cs
@@ -181,11 +181,13 @@ namespace UDS.Net.Forms.Tests
             await Page.Locator("input[name=\"A4a.TRTBIOMARK\"][value=\"1\"]").ClickAsync();
 
             // Fill first treatment
-            await Page.Locator("input[name=\"A4a.Treatments[0].TARGETAB\"]").CheckAsync();
+            await Page.Locator("input[type=\"checkbox\"][name=\"A4a.Treatments[0].TARGETAB\"]").CheckAsync();
             await Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]").FillAsync("Trial A");
             await Page.Locator("input[name=\"A4a.Treatments[0].NCTNUM\"]").FillAsync("NCT123");
             await Page.Locator("input[name=\"A4a.Treatments[0].STARTMO\"]").FillAsync("01");
             await Page.Locator("input[name=\"A4a.Treatments[0].STARTYEAR\"]").FillAsync("2020");
+            await Page.Locator("input[name=\"A4a.Treatments[0].CARETRIAL\"][value=\"3\"]").ClickAsync();
+            await Page.Locator("input[name=\"A4a.Treatments[0].TRIALGRP\"][value=\"1\"]").ClickAsync();
 
             // Save
             await Page.GetByLabel("Save status").SelectOptionAsync(new[] { "1" });
@@ -198,11 +200,13 @@ namespace UDS.Net.Forms.Tests
 
             // Verify autofill
             await Expect(Page.Locator("input[name=\"A4a.TRTBIOMARK\"][value=\"1\"]")).ToBeCheckedAsync();
-            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].TARGETAB\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[type=\"checkbox\"][name=\"A4a.Treatments[0].TARGETAB\"]")).ToBeCheckedAsync();
             await Expect(Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]")).ToHaveValueAsync("Trial A");
             await Expect(Page.Locator("input[name=\"A4a.Treatments[0].NCTNUM\"]")).ToHaveValueAsync("NCT123");
-            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].STARTMO\"]")).ToHaveValueAsync("01");
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].STARTMO\"]")).ToHaveValueAsync("1");
             await Expect(Page.Locator("input[name=\"A4a.Treatments[0].STARTYEAR\"]")).ToHaveValueAsync("2020");
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].CARETRIAL\"][value=\"3\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].TRIALGRP\"][value=\"1\"]")).ToBeCheckedAsync();
         }
 
         [TestMethod]
@@ -217,8 +221,8 @@ namespace UDS.Net.Forms.Tests
 
             // Set adverse events
             await Page.Locator("input[name=\"A4a.ADVEVENT\"][value=\"1\"]").ClickAsync();
-            await Page.Locator("input[name=\"A4a.ARIAE\"]").CheckAsync();
-            await Page.Locator("input[name=\"A4a.ADVERSEOTH\"]").CheckAsync();
+            await Page.Locator("input[type=\"checkbox\"][name=\"A4a.ARIAE\"]").CheckAsync();
+            await Page.Locator("input[type=\"checkbox\"][name=\"A4a.ADVERSEOTH\"]").CheckAsync();
             await Page.Locator("input[name=\"A4a.ADVERSEOTX\"]").FillAsync("Other event");
 
             // Save
@@ -232,8 +236,8 @@ namespace UDS.Net.Forms.Tests
 
             // Verify autofill
             await Expect(Page.Locator("input[name=\"A4a.ADVEVENT\"][value=\"1\"]")).ToBeCheckedAsync();
-            await Expect(Page.Locator("input[name=\"A4a.ARIAE\"]")).ToBeCheckedAsync();
-            await Expect(Page.Locator("input[name=\"A4a.ADVERSEOTH\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[type=\"checkbox\"][name=\"A4a.ARIAE\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[type=\"checkbox\"][name=\"A4a.ADVERSEOTH\"]")).ToBeCheckedAsync();
             await Expect(Page.Locator("input[name=\"A4a.ADVERSEOTX\"]")).ToHaveValueAsync("Other event");
         }
 

--- a/src/UDS.Net.Forms.Tests/A4aTests.cs
+++ b/src/UDS.Net.Forms.Tests/A4aTests.cs
@@ -170,7 +170,105 @@ namespace UDS.Net.Forms.Tests
             await Expect(Page.Locator("input[name=\"A4a.TRTBIOMARK\"]:checked")).ToHaveValueAsync("1");
         }
 
+        [TestMethod]
+        public async Task FollowUpVisitAutofillsA4aTreatmentsFromPreviousVisit()
+        {
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "A4a" }).GetByRole(AriaRole.Link).ClickAsync();
 
+            // Enable treatments
+            await Page.Locator("input[name=\"A4a.TRTBIOMARK\"][value=\"1\"]").ClickAsync();
+
+            // Fill first treatment
+            await Page.Locator("input[name=\"A4a.Treatments[0].TARGETAB\"]").CheckAsync();
+            await Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]").FillAsync("Trial A");
+            await Page.Locator("input[name=\"A4a.Treatments[0].NCTNUM\"]").FillAsync("NCT123");
+            await Page.Locator("input[name=\"A4a.Treatments[0].STARTMO\"]").FillAsync("01");
+            await Page.Locator("input[name=\"A4a.Treatments[0].STARTYEAR\"]").FillAsync("2020");
+
+            // Save
+            await Page.GetByLabel("Save status").SelectOptionAsync(new[] { "1" });
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            // Create follow-up visit
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "A4a" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            // Verify autofill
+            await Expect(Page.Locator("input[name=\"A4a.TRTBIOMARK\"][value=\"1\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].TARGETAB\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]")).ToHaveValueAsync("Trial A");
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].NCTNUM\"]")).ToHaveValueAsync("NCT123");
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].STARTMO\"]")).ToHaveValueAsync("01");
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].STARTYEAR\"]")).ToHaveValueAsync("2020");
+        }
+
+        [TestMethod]
+        public async Task FollowUpVisitAutofillsA4aAdverseEvents()
+        {
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "A4a" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            // Enable treatments first (required for ADVEVENT)
+            await Page.Locator("input[name=\"A4a.TRTBIOMARK\"][value=\"1\"]").ClickAsync();
+
+            // Set adverse events
+            await Page.Locator("input[name=\"A4a.ADVEVENT\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[name=\"A4a.ARIAE\"]").CheckAsync();
+            await Page.Locator("input[name=\"A4a.ADVERSEOTH\"]").CheckAsync();
+            await Page.Locator("input[name=\"A4a.ADVERSEOTX\"]").FillAsync("Other event");
+
+            // Save
+            await Page.GetByLabel("Save status").SelectOptionAsync(new[] { "1" });
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            // Follow-up visit
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "A4a" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            // Verify autofill
+            await Expect(Page.Locator("input[name=\"A4a.ADVEVENT\"][value=\"1\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[name=\"A4a.ARIAE\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[name=\"A4a.ADVERSEOTH\"]")).ToBeCheckedAsync();
+            await Expect(Page.Locator("input[name=\"A4a.ADVERSEOTX\"]")).ToHaveValueAsync("Other event");
+        }
+
+        [TestMethod]
+        public async Task FollowUpVisitOverridesAutofillForA4a()
+        {
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "A4a" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            await Page.Locator("input[name=\"A4a.TRTBIOMARK\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]").FillAsync("Original Trial");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync(new[] { "1" });
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            // Follow-up
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "A4a" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            // Verify autofill
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]")).ToHaveValueAsync("Original Trial");
+
+            // Change value
+            await Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]").FillAsync("Updated Trial");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync(new[] { "1" });
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            // Reopen and confirm override
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "A4a" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            await Expect(Page.Locator("input[name=\"A4a.Treatments[0].TRTTRIAL\"]")).ToHaveValueAsync("Updated Trial");
+        }
 
     }
 }

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>16.2.11</ReleaseVersion>
+		<ReleaseVersion>16.2.12</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
+++ b/src/UDS.Net.Forms/Extensions/DomainToViewModelMapper.cs
@@ -412,6 +412,10 @@ namespace UDS.Net.Forms.Extensions
             {
                 vm = ((B9FormFields)form.Fields).PreviousVisitToVM(form.Id);
             }
+            else if (form.Fields is A4aFormFields)
+            {
+                vm = ((A4aFormFields)form.Fields).PreviousVisitToVM(form.Id);
+            }
 
             SetFormBaseProperties(form, vm);
 
@@ -727,6 +731,27 @@ namespace UDS.Net.Forms.Extensions
 
             };
         }
+
+        public static A4a PreviousVisitToVM(this A4aFormFields fields, int formId)
+        {
+            return new A4a()
+            {
+                Id = formId,
+                AllowedFormModes = fields.FormModes.Select(f => (int)f).ToList(),
+                AllowedRemoteModalities = fields.RemoteModalities.Select(f => (int)f).ToList(),
+                AllowedNotIncludedReasonCodes = fields.NotIncludedReasonCodes.Select(f => (int)f).ToList(),
+                AllowedAdministrationCodes = fields.AdministrationFormats.Select(f => (int)f).ToList(),
+                ADVEVENT = fields.ADVEVENT,
+                ARIAE = fields.ARIAE,
+                ARIAH = fields.ARIAH,
+                ADVERSEOTH = fields.ADVERSEOTH,
+                ADVERSEOTX = fields.ADVERSEOTX,
+                TRTBIOMARK = fields.TRTBIOMARK,
+                Treatments = fields.TreatmentFormFields.Select(s => s.ToVM(formId)).ToList(),
+
+            };
+        }
+
         public static A4aTreatment ToVM(this A4aTreatmentFormFields fields, int formId)
         {
             return new A4aTreatment()

--- a/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml.cs
+++ b/src/UDS.Net.Forms/Pages/UDS4/A4a.cshtml.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using UDS.Net.Forms.Extensions;
 using UDS.Net.Forms.Models.PageModels;
 using UDS.Net.Forms.Models.UDS4;
 using UDS.Net.Forms.TagHelpers;
 using UDS.Net.Services;
+using UDS.Net.Services.Enums;
 
 namespace UDS.Net.Forms.Pages.UDS4
 {
@@ -91,6 +93,40 @@ namespace UDS.Net.Forms.Pages.UDS4
             if (BaseForm != null)
             {
                 A4a = (A4a)BaseForm;
+            }
+
+            if (A4a.PacketKind == PacketKind.F && BaseForm.Id == 0)
+            {
+
+                int countOfVisits = await _visitService.GetVisitCountByVersion(
+                    User.Identity!.Name!,
+                    Visit.ParticipationId,
+                    "4.0.0");
+
+                if (Visit.VISITNUM >= countOfVisits && countOfVisits > 1)
+                {
+                    var previousVisit = await _visitService.GetWithFormByParticipantAndVisitNumber(
+                        User.Identity!.Name!,
+                        Visit.ParticipationId,
+                        Visit.VISITNUM - 1,
+                        "A4a");
+
+                    if (previousVisit != null)
+                    {
+                        var previousA4aForm = previousVisit.Forms
+                            .Where(f => f.Kind == "A4a")
+                            .FirstOrDefault();
+
+                        if (previousA4aForm != null)
+                        {
+                            var previousFormModel = previousA4aForm.PreviousVisitToVM();
+
+                            A4a = (A4a)previousFormModel;
+
+                            A4a.SetBaseProperties(BaseForm);
+                        }
+                    }
+                }
             }
 
             return Page();

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>16.2.11</Version>
+		<Version>16.2.12</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>16.2.11</ReleaseVersion>
+		<ReleaseVersion>16.2.12</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>16.2.11</ReleaseVersion>
+		<ReleaseVersion>16.2.12</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>16.2.11</Version>
+		<Version>16.2.12</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>16.2.11</ReleaseVersion>
+		<ReleaseVersion>16.2.12</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.1" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>16.2.11</Version>
+		<Version>16.2.12</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>16.2.11</ReleaseVersion>
+		<ReleaseVersion>16.2.12</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>16.2.11</ReleaseVersion>
+		<ReleaseVersion>16.2.12</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves #667 
- [x] Started PR in draft.
- [x]  Stepped through new code line-by-line with the debugger ↪️
- [x] UI changes? Extensively tested with browser dev tools: inspect the markup, look at the console logs, and network requests. 📈
 - [x] Ran unit or Playwright tests locally (if applicable). 🧪
 - [x] Captured screenshots 💻
 - [x] Wrote a great PR description (see [here](https://github.com/UK-SBCoA/COA/wiki/PR-Standards)) 🦖
 - [x] Marked PR as ready for review and moved into 👀 In review
## Autofill A4a
Autofills the A4a form with the values of the previous visit.

<img width="1374" height="843" alt="image" src="https://github.com/user-attachments/assets/b19563a2-e2f2-449d-bf53-077216a1241a" />
<img width="1354" height="504" alt="image" src="https://github.com/user-attachments/assets/73eea155-8067-4b63-9fdd-23782a570493" />

- Previous Visit

<img width="1374" height="843" alt="image" src="https://github.com/user-attachments/assets/eeb2a78d-8c39-4a0b-90eb-03b472a040ca" />
<img width="1338" height="507" alt="image" src="https://github.com/user-attachments/assets/a1c3d204-3061-4317-b376-15203fb68efe" />

- Next Visit

Also added playwright tests to test autofilling, and editing the autofilled forms.
