### PR TITLE
Adjust GetEncodedValue helper method to return code for null matches

### DIFF
--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.1</ReleaseVersion>
+		<ReleaseVersion>17.0.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.1</ReleaseVersion>
+		<ReleaseVersion>17.0.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.1</Version>
+		<Version>17.0.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.1</ReleaseVersion>
+		<ReleaseVersion>17.0.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.1</ReleaseVersion>
+		<ReleaseVersion>17.0.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services/DomainModels/Forms/A3FamilyMemberFormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A3FamilyMemberFormFields.cs
@@ -18,6 +18,7 @@ namespace UDS.Net.Services.DomainModels.Forms
             {
                 A3FamilyMemberFormFields encodedFamilyMemberFormFields = new A3FamilyMemberFormFields();
 
+                encodedFamilyMemberFormFields.FamilyMemberIndex = previousFamilyMemberFormFields.FamilyMemberIndex;
                 encodedFamilyMemberFormFields.YOB = ExportHelper.GetEncodedValue(previousFamilyMemberFormFields.YOB, this.YOB, 6666, hasNewInformation);
                 encodedFamilyMemberFormFields.AGD = ExportHelper.GetEncodedValue(previousFamilyMemberFormFields.AGD, this.AGD, 666, hasNewInformation);
                 encodedFamilyMemberFormFields.ETPR = ExportHelper.GetEncodedValue(previousFamilyMemberFormFields.ETPR, this.ETPR, "66", hasNewInformation);

--- a/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
@@ -105,11 +105,33 @@ namespace UDS.Net.Services.DomainModels.Forms
                 //Encode siblings and kids
                 if (encodedFormFields.SiblingFormFields != null)
                 {
-                    encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) => siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation)).ToList();
+                    //encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) => siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation)).ToList();
+
+                    encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) =>
+                    {
+                        if(index <= previousA3Fields.SIBS)
+                        {
+                            return siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation);
+                        }
+
+                        return null;
+
+                    }).ToList();
                 }
                 if (encodedFormFields.KidsFormFields != null)
                 {
-                    encodedFormFields.KidsFormFields = encodedFormFields.KidsFormFields.Select((siblingFields, index) => siblingFields.GetEncodedFormFields(previousA3Fields.KidsFormFields[index], hasNewInformation => encodedFormFields.NWINFKID = hasNewInformation)).ToList();
+                    //encodedFormFields.KidsFormFields = encodedFormFields.KidsFormFields.Select((siblingFields, index) => siblingFields.GetEncodedFormFields(previousA3Fields.KidsFormFields[index], hasNewInformation => encodedFormFields.NWINFKID = hasNewInformation)).ToList();
+
+                    encodedFormFields.KidsFormFields = encodedFormFields.KidsFormFields.Select((siblingFields, index) =>
+                    {
+                        if (index <= previousA3Fields.KIDS)
+                        {
+                            return siblingFields.GetEncodedFormFields(previousA3Fields.KidsFormFields[index], hasNewInformation => encodedFormFields.NWINFKID = hasNewInformation);
+                        }
+
+                        return null;
+
+                    }).ToList();
                 }
 
                 return encodedFormFields;

--- a/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
@@ -107,7 +107,7 @@ namespace UDS.Net.Services.DomainModels.Forms
                 {
                     encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) =>
                     {
-                        if (index <= previousA3Fields.SIBS)
+                        if (index < previousA3Fields.SIBS)
                         {
                             return siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation);
                         }
@@ -120,7 +120,7 @@ namespace UDS.Net.Services.DomainModels.Forms
                 {
                     encodedFormFields.KidsFormFields = encodedFormFields.KidsFormFields.Select((siblingFields, index) =>
                     {
-                        if (index <= previousA3Fields.KIDS)
+                        if (index < previousA3Fields.KIDS)
                         {
                             return siblingFields.GetEncodedFormFields(previousA3Fields.KidsFormFields[index], hasNewInformation => encodedFormFields.NWINFKID = hasNewInformation);
                         }

--- a/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
@@ -114,7 +114,7 @@ namespace UDS.Net.Services.DomainModels.Forms
                             return siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation);
                         }
 
-                        return null;
+                        return encodedFormFields.SiblingFormFields[index];
 
                     }).ToList();
                 }
@@ -129,7 +129,7 @@ namespace UDS.Net.Services.DomainModels.Forms
                             return siblingFields.GetEncodedFormFields(previousA3Fields.KidsFormFields[index], hasNewInformation => encodedFormFields.NWINFKID = hasNewInformation);
                         }
 
-                        return null;
+                        return encodedFormFields.KidsFormFields[index];
 
                     }).ToList();
                 }

--- a/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
@@ -109,7 +109,7 @@ namespace UDS.Net.Services.DomainModels.Forms
 
                     encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) =>
                     {
-                        if(index <= previousA3Fields.SIBS)
+                        if (index <= previousA3Fields.SIBS)
                         {
                             return siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation);
                         }

--- a/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
@@ -107,7 +107,7 @@ namespace UDS.Net.Services.DomainModels.Forms
                 {
                     encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) =>
                     {
-                        if (index < previousA3Fields.SIBS)
+                        if (index < (encodedFormFields.SIBS != 66 ? encodedFormFields.SIBS : previousA3Fields.SIBS))
                         {
                             return siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation);
                         }
@@ -120,7 +120,7 @@ namespace UDS.Net.Services.DomainModels.Forms
                 {
                     encodedFormFields.KidsFormFields = encodedFormFields.KidsFormFields.Select((siblingFields, index) =>
                     {
-                        if (index < previousA3Fields.KIDS)
+                        if (index < (encodedFormFields.KIDS != 66 ? encodedFormFields.KIDS : previousA3Fields.KIDS))
                         {
                             return siblingFields.GetEncodedFormFields(previousA3Fields.KidsFormFields[index], hasNewInformation => encodedFormFields.NWINFKID = hasNewInformation);
                         }

--- a/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
+++ b/src/UDS.Net.Services/DomainModels/Forms/A3FormFields.cs
@@ -105,8 +105,6 @@ namespace UDS.Net.Services.DomainModels.Forms
                 //Encode siblings and kids
                 if (encodedFormFields.SiblingFormFields != null)
                 {
-                    //encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) => siblingFields.GetEncodedFormFields(previousA3Fields.SiblingFormFields[index], hasNewInformation => encodedFormFields.NWINFSIB = hasNewInformation)).ToList();
-
                     encodedFormFields.SiblingFormFields = encodedFormFields.SiblingFormFields.Select((siblingFields, index) =>
                     {
                         if (index <= previousA3Fields.SIBS)
@@ -120,8 +118,6 @@ namespace UDS.Net.Services.DomainModels.Forms
                 }
                 if (encodedFormFields.KidsFormFields != null)
                 {
-                    //encodedFormFields.KidsFormFields = encodedFormFields.KidsFormFields.Select((siblingFields, index) => siblingFields.GetEncodedFormFields(previousA3Fields.KidsFormFields[index], hasNewInformation => encodedFormFields.NWINFKID = hasNewInformation)).ToList();
-
                     encodedFormFields.KidsFormFields = encodedFormFields.KidsFormFields.Select((siblingFields, index) =>
                     {
                         if (index <= previousA3Fields.KIDS)

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.1</Version>
+		<Version>17.0.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.1</ReleaseVersion>
+		<ReleaseVersion>17.0.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.3" />

--- a/src/UDS.Net.Services/Utilities/ExportHelper.cs
+++ b/src/UDS.Net.Services/Utilities/ExportHelper.cs
@@ -6,11 +6,6 @@ namespace UDS.Net.Services.Utilities
     {
         public static int? GetEncodedValue(int? previousValue, int? currentValue, int code, Action<int?> newInformationPropSetter)
         {
-            if (previousValue == null && currentValue == null)
-            {
-                return null;
-            }
-
             if (previousValue == currentValue)
             {
                 return code;
@@ -22,11 +17,6 @@ namespace UDS.Net.Services.Utilities
 
         public static string GetEncodedValue(string previousValue, string currentValue, string code, Action<int?> newInformationPropSetter)
         {
-            if (previousValue == null && currentValue == null)
-            {
-                return null;
-            }
-
             if (previousValue == currentValue)
             {
                 return code;

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.1</Version>
+		<Version>17.0.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.1</ReleaseVersion>
+		<ReleaseVersion>17.0.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.1</ReleaseVersion>
+		<ReleaseVersion>17.0.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves: #701 

## Change the way that A3 handles NULL values between initial and follow-up visits
Instead of exporting value as NULL when the previous visit is NULL for ETSEC, MEVAL, and AGEO for mom, dad, sibling, and kid, we will provide a previous visit code when the section has changed

- [ ] Disabled values in changed sections export as encoded values instead of NULL
- [ ] Unprovided Kids and Sibs in changed sections remain NULL instead of using encoded values
- [ ] Unchanged sections continue to export NULL for sections that have not changed


### Error codes when section is changed and value is disabled (Parent section)  
#### Form view
<img width="1820" height="221" alt="image" src="https://github.com/user-attachments/assets/ce3ab54d-ecc7-49b8-9446-9ca9d7099538" />

#### Export view
<img width="721" height="76" alt="image" src="https://github.com/user-attachments/assets/a3d154cd-5d18-4195-bae3-34de1c1f74e1" />

> Instead of exporting NULL for MOMETSEC, MOMMEVAL, MOMAGEO previous value codes are provided

### Error codes when section is changed and value is disabled (Sibling section)  

#### Form view
<img width="1815" height="496" alt="image" src="https://github.com/user-attachments/assets/a4783f4a-fe89-4d7b-be0b-9a89cb31500a" />

#### Export view (disabled values in siblings)
<img width="1158" height="83" alt="image" src="https://github.com/user-attachments/assets/7496c4e9-c634-4237-bbed-84bbf3e05b41" />

> If section is changed, then provide encode values for disabled fields when sibling was provided

#### Export view (unprovided siblings)
<img width="765" height="81" alt="image" src="https://github.com/user-attachments/assets/df3caf07-0c6e-4460-a1b1-c907041b1e35" />

> Siblings that were not provided remain as NULL



