### PR TITLE
Adjust validation to account for new udsverfc and udsverlc rule

### DIFF
--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.13</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
+++ b/src/UDS.Net.Forms.Tests.Runtime/UDS.Net.Forms.Tests.Runtime.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
+		<ReleaseVersion>17.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
 	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />

--- a/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
+++ b/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
@@ -1,18 +1,14 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.Playwright;
-using System;
-using System.Collections.Generic;
-using System.Net.NetworkInformation;
-using System.Text;
+﻿using Microsoft.Playwright;
 
 namespace UDS.Net.Forms.Tests
 {
     [TestClass]
     public class C2VerbalFluencyTests : TestBase
     {
-        //Sets up the form leaving the verbal fluency test blank for manual inputs in tests
-        private async Task SetUpForm()
+        private async Task SetUpC2Form()
         {
+            await NavigateToC2View();
+
             await Page.Locator("input[type=\"radio\"][name=\"C2.MOCACOMP\"][value=\"0\"]").ClickAsync();
             await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]")).ToBeEnabledAsync();
             await Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]").FillAsync("95");
@@ -36,9 +32,7 @@ namespace UDS.Net.Forms.Tests
             await Page.Locator("input[type=\"radio\"][name=\"C2.RESPVAL\"][value=\"1\"]").ClickAsync();
         }
 
-        //Using both UDSVERFC and UDSVERLC error codes should disable all fields following them within section
-        [TestMethod]
-        public async Task UDSVERFCAndUDSVERLReasonCodesDisableFollowingFields()
+        private async Task NavigateToC2View()
         {
             //Navigate to the C2 form
             await Page.GotoAsync(BaseUrl);
@@ -48,8 +42,58 @@ namespace UDS.Net.Forms.Tests
             //Select in person view (C2)
             await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
 
-            //Set up the rest of the form
-            await SetUpForm();
+            //Wait for javascript to finish loading by identifying a C2 input
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCATOTS\"]")).ToBeDisabledAsync();
+        }
+
+        private async Task SetUpC2TForm()
+        {
+            await NavigateToC2TView();
+
+            await Page.Locator("input[type=\"radio\"][name=\"C2.MOCACOMP\"][value=\"0\"]").ClickAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]")).ToBeEnabledAsync();
+            await Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]").FillAsync("95");
+            await Page.Locator("input[type=\"radio\"][name=\"C2.NPSYLAN\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[name=\"C2.CRAFTVRS\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.DIGFORCT\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.DIGBACCT\"]").FillAsync("95");
+            await Page.Locator("input[type=\"radio\"][name=\"C2.VERBALTEST\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[name=\"C2.REY1REC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.ANIMALS\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.VEG\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.OTRAILA\"]").FillAsync("995");
+            await Page.Locator("input[name=\"C2.OTRAILB\"]").FillAsync("995");
+            await Page.Locator("input[name=\"C2.CRAFTDVR\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.REYDREC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.VNTTOTW\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.VNTPCNC\"]").FillAsync("95");
+            await Page.Locator("input[type=\"radio\"][name=\"C2.COGSTAT\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[type=\"radio\"][name=\"C2.RESPVAL\"][value=\"1\"]").ClickAsync();
+            await Page.GetByLabel("If remote, specify reason").SelectOptionAsync("TooCognitivelyImpaired");
+        }
+
+        private async Task NavigateToC2TView()
+        {
+            //Navigate to the _C2 view
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select the remote - telephone view (C2T)
+            await Page.Locator("#modalityselect").SelectOptionAsync("Remote");
+            await Page.Locator("#remote").SelectOptionAsync("Telephone");
+
+            //Wait for javascript to finish loading by identifying a C2T input
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCBTOTS\"]")).ToBeDisabledAsync();
+        }
+
+        //C2 test methods
+
+        //Using both UDSVERFC and UDSVERLC error codes should disable all fields following them within section
+        [TestMethod]
+        public async Task C2UDSVERFCAndUDSVERLReasonCodesDisableFollowingFields()
+        {
+            await SetUpC2Form();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
@@ -66,18 +110,9 @@ namespace UDS.Net.Forms.Tests
 
         //Using valid values for UDSVERFC and UDSVERLC should enable all fields following them within section
         [TestMethod]
-        public async Task UDSVERFCAndUDSVERLCValuesEnableFollowingFields()
+        public async Task C2UDSVERFCAndUDSVERLCValuesEnableFollowingFields()
         {
-            //Navigate to the C2 form
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
-
-            //Select in person view (C2)
-            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
-
-            //Set up the rest of the form
-            await SetUpForm();
+            await SetUpC2Form();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
@@ -94,18 +129,9 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank
         [TestMethod]
-        public async Task UDSVERFCReasonCodeRequiresTotalFieldsToBeNull()
+        public async Task C2UDSVERFCReasonCodeRequiresTotalFieldsToBeNull()
         {
-            //Navigate to the C2 form
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
-
-            //Select in person view (C2)
-            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
-
-            //Set up the rest of the form
-            await SetUpForm();
+            await SetUpC2Form();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
@@ -127,18 +153,9 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC
         [TestMethod]
-        public async Task UDSVERTNRequiresSumOfUDSVERFCAndUDSVERLCWhenBothAreValues()
+        public async Task C2UDSVERTNRequiresSumOfUDSVERFCAndUDSVERLCWhenBothAreValues()
         {
-            //Navigate to the C2 form
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
-
-            //Select in person view (C2)
-            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
-
-            //Set up the rest of the form
-            await SetUpForm();
+            await SetUpC2Form();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
@@ -160,18 +177,9 @@ namespace UDS.Net.Forms.Tests
 
         //When UDSVERFC and UDSVERLC are values, All questions can be given a value and save the form
         [TestMethod]
-        public async Task UDSVERFCAndUDSVERLCWithValuesAcceptsSectionCompletion()
+        public async Task C2UDSVERFCAndUDSVERLCWithValuesAcceptsSectionCompletion()
         {
-            //Navigate to the C2 form
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
-
-            //Select in person view (C2)
-            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
-
-            //Set up the rest of the form
-            await SetUpForm();
+            await SetUpC2Form();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
@@ -193,18 +201,9 @@ namespace UDS.Net.Forms.Tests
 
         //When UDSVERFC and UDSVERLC are reason codes, the form saves with null values for the rest of the section
         [TestMethod]
-        public async Task UDSVERFCAndUDSVERLCWithReasonCodesAcceptsNullValues()
+        public async Task C2UDSVERFCAndUDSVERLCWithReasonCodesAcceptsNullValues()
         {
-            //Navigate to the C2 form
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
-
-            //Select in person view (C2)
-            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
-
-            //Set up the rest of the form
-            await SetUpForm();
+            await SetUpC2Form();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
@@ -219,18 +218,9 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.
         [TestMethod]
-        public async Task UDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
+        public async Task C2UDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
         {
-            //Navigate to the C2 form
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
-
-            //Select in person view (C2)
-            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
-
-            //Set up the rest of the form
-            await SetUpForm();
+            await SetUpC2Form();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
@@ -252,18 +242,186 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR
         [TestMethod]
-        public async Task UDSVERTERequiresSumOfUDSVERFNAndUDSVERLRWhenBothAreValues()
+        public async Task C2UDSVERTERequiresSumOfUDSVERFNAndUDSVERLRWhenBothAreValues()
         {
-            //Navigate to the C2 form
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+            await SetUpC2Form();
 
-            //Select in person view (C2)
-            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("1");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("3");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("4");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("5");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("6");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("5");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("8");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("9");
 
-            //Set up the rest of the form
-            await SetUpForm();
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR" })).ToBeVisibleAsync();
+        }
+
+        //C2T test methods
+
+        //Using both UDSVERFC and UDSVERLC error codes should disable all fields following them within section
+        [TestMethod]
+        public async Task C2TUDSVERFCAndUDSVERLReasonCodesDisableFollowingFields()
+        {
+            await SetUpC2TForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("95");
+
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERFN\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERNF\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLR\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLN\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTN\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTE\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTI\"]")).ToBeDisabledAsync();
+        }
+
+        //Using valid values for UDSVERFC and UDSVERLC should enable all fields following them within section
+        [TestMethod]
+        public async Task C2TUDSVERFCAndUDSVERLCValuesEnableFollowingFields()
+        {
+            await SetUpC2TForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERFN\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERNF\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLR\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLN\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTN\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTE\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTI\"]")).ToBeEnabledAsync();
+        }
+
+        //If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank
+        [TestMethod]
+        public async Task C2TUDSVERFCReasonCodeRequiresTotalFieldsToBeNull()
+        {
+            await SetUpC2TForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            var blankInputErrorMessageLocator = Page.Locator("span").Filter(new() { HasText = "If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank" });
+
+            await Expect(blankInputErrorMessageLocator).ToHaveCountAsync(3);
+        }
+
+        //If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC
+        [TestMethod]
+        public async Task C2TUDSVERTNRequiresSumOfUDSVERFCAndUDSVERLCWhenBothAreValues()
+        {
+            await SetUpC2TForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC" })).ToBeVisibleAsync();
+        }
+
+        //When UDSVERFC and UDSVERLC are values, All questions can be given a value and save the form
+        [TestMethod]
+        public async Task C2TUDSVERFCAndUDSVERLCWithValuesAcceptsSectionCompletion()
+        {
+            await SetUpC2TForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("4");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for successful path to forms index on finalized save
+            await Expect(Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" })).ToBeVisibleAsync();
+        }
+
+        //When UDSVERFC and UDSVERLC are reason codes, the form saves with null values for the rest of the section
+        [TestMethod]
+        public async Task C2TUDSVERFCAndUDSVERLCWithReasonCodesAcceptsNullValues()
+        {
+            await SetUpC2TForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("95");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for successful path to forms index on finalized save
+            await Expect(Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" })).ToBeVisibleAsync();
+        }
+
+        //If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.
+        [TestMethod]
+        public async Task C2TUDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
+        {
+            await SetUpC2TForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("3");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("4");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("5");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("6");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("7");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("8");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("9");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN." })).ToBeVisibleAsync();
+        }
+
+        //If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR
+        [TestMethod]
+        public async Task C2TUDSVERTERequiresSumOfUDSVERFNAndUDSVERLRWhenBothAreValues()
+        {
+            await SetUpC2TForm();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("1");

--- a/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
+++ b/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
@@ -175,7 +175,7 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.
         [TestMethod]
-        public async Task UDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
+        public async Task UDSVERTIRequiresSumOfUDSVERNFAndUDSVERLNWhenBothAreValues()
         {
             await SetUpC2Form();
 

--- a/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
+++ b/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
@@ -220,5 +220,31 @@ namespace UDS.Net.Forms.Tests
             //Look for validation message to appear on properties
             await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR" })).ToBeVisibleAsync();
         }
+
+        //When UDSVERFC and UDSVERLC are values, All questions can be given a value and save the form
+        [TestMethod]
+        public async Task UDSVERFCAndUDSVERLCWithValuesRequiresSectionCompletion()
+        {
+            await SetUpC2Form();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("40");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("15");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("15");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("40");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("15");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("15");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("30");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            var valueRequiredErrorMessageLocator = Page.Locator("span").Filter(new() { HasText = "Value Required" });
+
+            await Expect(valueRequiredErrorMessageLocator).ToHaveCountAsync(2);
+        }
     }
 }

--- a/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
+++ b/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
@@ -9,7 +9,7 @@ namespace UDS.Net.Forms.Tests
 {
     [TestClass]
     public class C2VerbalFluencyTests : TestBase
-    { 
+    {
         //Sets up the form leaving the verbal fluency test blank for manual inputs in tests
         private async Task SetUpForm()
         {

--- a/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
+++ b/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
@@ -46,52 +46,9 @@ namespace UDS.Net.Forms.Tests
             await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCATOTS\"]")).ToBeDisabledAsync();
         }
 
-        private async Task SetUpC2TForm()
-        {
-            await NavigateToC2TView();
-
-            await Page.Locator("input[type=\"radio\"][name=\"C2.MOCACOMP\"][value=\"0\"]").ClickAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]")).ToBeEnabledAsync();
-            await Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]").FillAsync("95");
-            await Page.Locator("input[type=\"radio\"][name=\"C2.NPSYLAN\"][value=\"1\"]").ClickAsync();
-            await Page.Locator("input[name=\"C2.CRAFTVRS\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.DIGFORCT\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.DIGBACCT\"]").FillAsync("95");
-            await Page.Locator("input[type=\"radio\"][name=\"C2.VERBALTEST\"][value=\"1\"]").ClickAsync();
-            await Page.Locator("input[name=\"C2.REY1REC\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.ANIMALS\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.VEG\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.OTRAILA\"]").FillAsync("995");
-            await Page.Locator("input[name=\"C2.OTRAILB\"]").FillAsync("995");
-            await Page.Locator("input[name=\"C2.CRAFTDVR\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.REYDREC\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.VNTTOTW\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.VNTPCNC\"]").FillAsync("95");
-            await Page.Locator("input[type=\"radio\"][name=\"C2.COGSTAT\"][value=\"1\"]").ClickAsync();
-            await Page.Locator("input[type=\"radio\"][name=\"C2.RESPVAL\"][value=\"1\"]").ClickAsync();
-            await Page.GetByLabel("If remote, specify reason").SelectOptionAsync("TooCognitivelyImpaired");
-        }
-
-        private async Task NavigateToC2TView()
-        {
-            //Navigate to the _C2 view
-            await Page.GotoAsync(BaseUrl);
-            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" }).GetByRole(AriaRole.Link).ClickAsync();
-
-            //Select the remote - telephone view (C2T)
-            await Page.Locator("#modalityselect").SelectOptionAsync("Remote");
-            await Page.Locator("#remote").SelectOptionAsync("Telephone");
-
-            //Wait for javascript to finish loading by identifying a C2T input
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCBTOTS\"]")).ToBeDisabledAsync();
-        }
-
-        //C2 test methods
-
         //Using both UDSVERFC and UDSVERLC error codes should disable all fields following them within section
         [TestMethod]
-        public async Task C2UDSVERFCAndUDSVERLReasonCodesDisableFollowingFields()
+        public async Task UDSVERFCAndUDSVERLReasonCodesDisableFollowingFields()
         {
             await SetUpC2Form();
 
@@ -110,7 +67,7 @@ namespace UDS.Net.Forms.Tests
 
         //Using valid values for UDSVERFC and UDSVERLC should enable all fields following them within section
         [TestMethod]
-        public async Task C2UDSVERFCAndUDSVERLCValuesEnableFollowingFields()
+        public async Task UDSVERFCAndUDSVERLCValuesEnableFollowingFields()
         {
             await SetUpC2Form();
 
@@ -129,7 +86,7 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank
         [TestMethod]
-        public async Task C2UDSVERFCReasonCodeRequiresTotalFieldsToBeNull()
+        public async Task UDSVERFCReasonCodeRequiresTotalFieldsToBeNull()
         {
             await SetUpC2Form();
 
@@ -153,7 +110,7 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC
         [TestMethod]
-        public async Task C2UDSVERTNRequiresSumOfUDSVERFCAndUDSVERLCWhenBothAreValues()
+        public async Task UDSVERTNRequiresSumOfUDSVERFCAndUDSVERLCWhenBothAreValues()
         {
             await SetUpC2Form();
 
@@ -177,7 +134,7 @@ namespace UDS.Net.Forms.Tests
 
         //When UDSVERFC and UDSVERLC are values, All questions can be given a value and save the form
         [TestMethod]
-        public async Task C2UDSVERFCAndUDSVERLCWithValuesAcceptsSectionCompletion()
+        public async Task UDSVERFCAndUDSVERLCWithValuesAcceptsSectionCompletion()
         {
             await SetUpC2Form();
 
@@ -201,7 +158,7 @@ namespace UDS.Net.Forms.Tests
 
         //When UDSVERFC and UDSVERLC are reason codes, the form saves with null values for the rest of the section
         [TestMethod]
-        public async Task C2UDSVERFCAndUDSVERLCWithReasonCodesAcceptsNullValues()
+        public async Task UDSVERFCAndUDSVERLCWithReasonCodesAcceptsNullValues()
         {
             await SetUpC2Form();
 
@@ -218,7 +175,7 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.
         [TestMethod]
-        public async Task C2UDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
+        public async Task UDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
         {
             await SetUpC2Form();
 
@@ -242,186 +199,9 @@ namespace UDS.Net.Forms.Tests
 
         //If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR
         [TestMethod]
-        public async Task C2UDSVERTERequiresSumOfUDSVERFNAndUDSVERLRWhenBothAreValues()
+        public async Task UDSVERTERequiresSumOfUDSVERFNAndUDSVERLRWhenBothAreValues()
         {
             await SetUpC2Form();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("1");
-            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("3");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("4");
-            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("5");
-            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("6");
-            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("5");
-            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("8");
-            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("9");
-
-            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
-            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
-
-            //Look for validation message to appear on properties
-            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR" })).ToBeVisibleAsync();
-        }
-
-        //C2T test methods
-
-        //Using both UDSVERFC and UDSVERLC error codes should disable all fields following them within section
-        [TestMethod]
-        public async Task C2TUDSVERFCAndUDSVERLReasonCodesDisableFollowingFields()
-        {
-            await SetUpC2TForm();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("95");
-
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERFN\"]")).ToBeDisabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERNF\"]")).ToBeDisabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLR\"]")).ToBeDisabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLN\"]")).ToBeDisabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTN\"]")).ToBeDisabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTE\"]")).ToBeDisabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTI\"]")).ToBeDisabledAsync();
-        }
-
-        //Using valid values for UDSVERFC and UDSVERLC should enable all fields following them within section
-        [TestMethod]
-        public async Task C2TUDSVERFCAndUDSVERLCValuesEnableFollowingFields()
-        {
-            await SetUpC2TForm();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
-
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERFN\"]")).ToBeEnabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERNF\"]")).ToBeEnabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLR\"]")).ToBeEnabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLN\"]")).ToBeEnabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTN\"]")).ToBeEnabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTE\"]")).ToBeEnabledAsync();
-            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTI\"]")).ToBeEnabledAsync();
-        }
-
-        //If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank
-        [TestMethod]
-        public async Task C2TUDSVERFCReasonCodeRequiresTotalFieldsToBeNull()
-        {
-            await SetUpC2TForm();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
-
-            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
-            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
-
-            //Look for validation message to appear on properties
-            var blankInputErrorMessageLocator = Page.Locator("span").Filter(new() { HasText = "If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank" });
-
-            await Expect(blankInputErrorMessageLocator).ToHaveCountAsync(3);
-        }
-
-        //If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC
-        [TestMethod]
-        public async Task C2TUDSVERTNRequiresSumOfUDSVERFCAndUDSVERLCWhenBothAreValues()
-        {
-            await SetUpC2TForm();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
-
-            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
-            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
-
-            //Look for validation message to appear on properties
-            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC" })).ToBeVisibleAsync();
-        }
-
-        //When UDSVERFC and UDSVERLC are values, All questions can be given a value and save the form
-        [TestMethod]
-        public async Task C2TUDSVERFCAndUDSVERLCWithValuesAcceptsSectionCompletion()
-        {
-            await SetUpC2TForm();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("4");
-            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
-            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
-
-            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
-            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
-
-            //Look for successful path to forms index on finalized save
-            await Expect(Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" })).ToBeVisibleAsync();
-        }
-
-        //When UDSVERFC and UDSVERLC are reason codes, the form saves with null values for the rest of the section
-        [TestMethod]
-        public async Task C2TUDSVERFCAndUDSVERLCWithReasonCodesAcceptsNullValues()
-        {
-            await SetUpC2TForm();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("95");
-
-            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
-            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
-
-            //Look for successful path to forms index on finalized save
-            await Expect(Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" })).ToBeVisibleAsync();
-        }
-
-        //If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.
-        [TestMethod]
-        public async Task C2TUDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
-        {
-            await SetUpC2TForm();
-
-            //Provide values for verbal fluency section
-            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("3");
-            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("4");
-            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
-            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("5");
-            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("6");
-            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("7");
-            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("8");
-            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("9");
-
-            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
-            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
-
-            //Look for validation message to appear on properties
-            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN." })).ToBeVisibleAsync();
-        }
-
-        //If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR
-        [TestMethod]
-        public async Task C2TUDSVERTERequiresSumOfUDSVERFNAndUDSVERLRWhenBothAreValues()
-        {
-            await SetUpC2TForm();
 
             //Provide values for verbal fluency section
             await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("1");

--- a/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
+++ b/src/UDS.Net.Forms.Tests/C2VerbalFluencyTests.cs
@@ -1,0 +1,286 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Playwright;
+using System;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+using System.Text;
+
+namespace UDS.Net.Forms.Tests
+{
+    [TestClass]
+    public class C2VerbalFluencyTests : TestBase
+    { 
+        //Sets up the form leaving the verbal fluency test blank for manual inputs in tests
+        private async Task SetUpForm()
+        {
+            await Page.Locator("input[type=\"radio\"][name=\"C2.MOCACOMP\"][value=\"0\"]").ClickAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]")).ToBeEnabledAsync();
+            await Page.Locator("input[type=\"number\"][name=\"C2.MOCAREAS\"]").FillAsync("95");
+            await Page.Locator("input[type=\"radio\"][name=\"C2.NPSYCLOC\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[type=\"radio\"][name=\"C2.NPSYLAN\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[name=\"C2.CRAFTVRS\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.UDSBENTC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.DIGFORCT\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.DIGBACCT\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.ANIMALS\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.VEG\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.TRAILA\"]").FillAsync("995");
+            await Page.Locator("input[name=\"C2.TRAILB\"]").FillAsync("995");
+            await Page.Locator("input[name=\"C2.UDSBENTD\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.CRAFTDVR\"]").FillAsync("95");
+            await Page.Locator("input[type=\"radio\"][name=\"C2.VERBALTEST\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[name=\"C2.REY1REC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.REYDREC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.MINTTOTS\"]").FillAsync("95");
+            await Page.Locator("input[type=\"radio\"][name=\"C2.COGSTAT\"][value=\"1\"]").ClickAsync();
+            await Page.Locator("input[type=\"radio\"][name=\"C2.RESPVAL\"][value=\"1\"]").ClickAsync();
+        }
+
+        //Using both UDSVERFC and UDSVERLC error codes should disable all fields following them within section
+        [TestMethod]
+        public async Task UDSVERFCAndUDSVERLReasonCodesDisableFollowingFields()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("95");
+
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERFN\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERNF\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLR\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLN\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTN\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTE\"]")).ToBeDisabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTI\"]")).ToBeDisabledAsync();
+        }
+
+        //Using valid values for UDSVERFC and UDSVERLC should enable all fields following them within section
+        [TestMethod]
+        public async Task UDSVERFCAndUDSVERLCValuesEnableFollowingFields()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERFN\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERNF\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLR\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERLN\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTN\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTE\"]")).ToBeEnabledAsync();
+            await Expect(Page.Locator("input[type=\"number\"][name=\"C2.UDSVERTI\"]")).ToBeEnabledAsync();
+        }
+
+        //If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank
+        [TestMethod]
+        public async Task UDSVERFCReasonCodeRequiresTotalFieldsToBeNull()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            var blankInputErrorMessageLocator = Page.Locator("span").Filter(new() { HasText = "If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank" });
+
+            await Expect(blankInputErrorMessageLocator).ToHaveCountAsync(3);
+        }
+
+        //If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC
+        [TestMethod]
+        public async Task UDSVERTNRequiresSumOfUDSVERFCAndUDSVERLCWhenBothAreValues()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERFC not 95-98 and UDSVERLC not 95-98, UDSVERTN must be the total of UDSVERFC and UDSVERLC" })).ToBeVisibleAsync();
+        }
+
+        //When UDSVERFC and UDSVERLC are values, All questions can be given a value and save the form
+        [TestMethod]
+        public async Task UDSVERFCAndUDSVERLCWithValuesAcceptsSectionCompletion()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("4");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("0");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("0");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for successful path to forms index on finalized save
+            await Expect(Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" })).ToBeVisibleAsync();
+        }
+
+        //When UDSVERFC and UDSVERLC are reason codes, the form saves with null values for the rest of the section
+        [TestMethod]
+        public async Task UDSVERFCAndUDSVERLCWithReasonCodesAcceptsNullValues()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("95");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("95");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for successful path to forms index on finalized save
+            await Expect(Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2" })).ToBeVisibleAsync();
+        }
+
+        //If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN.
+        [TestMethod]
+        public async Task UDSVERTIRequiresSumOfUDSVERFNAndUDSVERLNWhenBothAreValues()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("3");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("4");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("5");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("6");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("7");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("8");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("9");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERNF and UDSVERLN are both within valid ranges (0-15) then UDSVERTI should equal the sum of UDSVERNF and UDSVERLN." })).ToBeVisibleAsync();
+        }
+
+        //If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR
+        [TestMethod]
+        public async Task UDSVERTERequiresSumOfUDSVERFNAndUDSVERLRWhenBothAreValues()
+        {
+            //Navigate to the C2 form
+            await Page.GotoAsync(BaseUrl);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "New visit" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Listitem).Filter(new() { HasText = "C2 Required" }).GetByRole(AriaRole.Link).ClickAsync();
+
+            //Select in person view (C2)
+            await Page.Locator("#modalityselect").SelectOptionAsync("InPerson");
+
+            //Set up the rest of the form
+            await SetUpForm();
+
+            //Provide values for verbal fluency section
+            await Page.Locator("input[name=\"C2.UDSVERFC\"]").FillAsync("1");
+            await Page.Locator("input[name=\"C2.UDSVERFN\"]").FillAsync("2");
+            await Page.Locator("input[name=\"C2.UDSVERNF\"]").FillAsync("3");
+            await Page.Locator("input[name=\"C2.UDSVERLC\"]").FillAsync("4");
+            await Page.Locator("input[name=\"C2.UDSVERLR\"]").FillAsync("5");
+            await Page.Locator("input[name=\"C2.UDSVERLN\"]").FillAsync("6");
+            await Page.Locator("input[name=\"C2.UDSVERTN\"]").FillAsync("5");
+            await Page.Locator("input[name=\"C2.UDSVERTE\"]").FillAsync("8");
+            await Page.Locator("input[name=\"C2.UDSVERTI\"]").FillAsync("9");
+
+            await Page.GetByLabel("Save status").SelectOptionAsync("Finalized");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+
+            //Look for validation message to appear on properties
+            await Expect(Page.Locator("span").Filter(new() { HasText = "If UDSVERFN (f-words repeated) is between 0 and 15 and UDSVERLR (l-words repeated) is between 0 and 15, then UDSVERTE must be the total of UDSVERFN and UDSVERLR" })).ToBeVisibleAsync();
+        }
+    }
+}

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
+		<ReleaseVersion>17.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.13</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
+++ b/src/UDS.Net.Forms.Tests/UDS.Net.Forms.Tests.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -1130,7 +1130,7 @@ namespace UDS.Net.Forms.Models.UDS4
         }
 
         [NotMapped]
-        [RequiredIfRange(nameof(UDSVERFC), 95, 98, ErrorMessage = "If UDSVERFC (correct f-words is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank")]
+        [RequiredIfRange(nameof(UDSVERFC), 95, 98, ErrorMessage = "If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank")]
         public bool? UDSVERFCReasonCodeValidation
         {
             get

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -521,17 +521,14 @@ namespace UDS.Net.Forms.Models.UDS4
 
         [Display(Name = "TOTAL number of correct F-words and L-words", Description = "(0-80)")]
         [Range(0, 80, ErrorMessage = "Allowed values are 0-80.")]
-        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Provide count of correct F-words and L-words.")]
         public int? UDSVERTN { get; set; }
 
         [Display(Name = "TOTAL number of F-word and L-word repetition errors", Description = "(0-30)")]
         [Range(0, 30, ErrorMessage = "Allowed values are 0-30.")]
-        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Provide count of F-word and L-word repetition errors.")]
         public int? UDSVERTE { get; set; }
 
         [Display(Name = "TOTAL number of non-F/L words and rule violation errors", Description = "(0-30)")]
         [Range(0, 30, ErrorMessage = "Allowed values are 0-30.")]
-        [RequiredIfRange(nameof(UDSVERLC), 0, 40, ErrorMessage = "Provide count of non-F/L words and rule violation errors.")]
         public int? UDSVERTI { get; set; }
 
         //If UDSVERNF and UDSVERLN are both valid values, then UDSVERTI must = UDSVERNF + UDSVERLN
@@ -1129,6 +1126,24 @@ namespace UDS.Net.Forms.Models.UDS4
                 }
 
                 return true;
+            }
+        }
+
+        [NotMapped]
+        [RequiredIfRange(nameof(UDSVERFC), 95, 98, ErrorMessage = "If q11a.UDSVERFC (correct f-words is between 95 and 98 or q11d.UDSVERLC (I-words correct) is between 95 and 98, then 11g, 11h, and 11i must be blank")]
+        public bool? UDSVERFCReasonCodeValidation
+        {
+            get
+            {
+                if ((UDSVERFC.HasValue && UDSVERFC >= 95) || (UDSVERLC.HasValue && UDSVERLC.Value >= 95))
+                {
+                    if (UDSVERTN == null && UDSVERTE == null && UDSVERTI == null)
+                    {
+                        return true;
+                    }
+                }
+
+                return null;
             }
         }
 

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -1130,7 +1130,7 @@ namespace UDS.Net.Forms.Models.UDS4
         }
 
         [NotMapped]
-        [RequiredIfRange(nameof(UDSVERFC), 95, 98, ErrorMessage = "If q11a.UDSVERFC (correct f-words is between 95 and 98 or q11d.UDSVERLC (I-words correct) is between 95 and 98, then 11g, 11h, and 11i must be blank")]
+        [RequiredIfRange(nameof(UDSVERFC), 95, 98, ErrorMessage = "If UDSVERFC (correct f-words is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank")]
         public bool? UDSVERFCReasonCodeValidation
         {
             get

--- a/src/UDS.Net.Forms/Models/UDS4/C2.cs
+++ b/src/UDS.Net.Forms/Models/UDS4/C2.cs
@@ -1010,6 +1010,42 @@ namespace UDS.Net.Forms.Models.UDS4
         }
 
         [NotMapped]
+        [RequiredIfRange(nameof(UDSVERFC), 0, 40, ErrorMessage = "Value required")]
+        public bool? UDSVERTNValueValidation
+        {
+            get
+            {
+                if ((UDSVERFC.HasValue && UDSVERFC.Value <= 40) && (UDSVERLC.HasValue && UDSVERLC.Value <= 40))
+                {
+                    if (!UDSVERTN.HasValue)
+                    {
+                        return null;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        [NotMapped]
+        [RequiredIfRange(nameof(UDSVERFC), 0, 40, ErrorMessage = "Value required")]
+        public bool? UDSVERTEValueValidation
+        {
+            get
+            {
+                if ((UDSVERFC.HasValue && UDSVERFC.Value <= 40) && (UDSVERLC.HasValue && UDSVERLC.Value <= 40))
+                {
+                    if (!UDSVERTE.HasValue)
+                    {
+                        return null;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        [NotMapped]
         [RequiredOnFinalized(ErrorMessage = "If Q14a. CERAD1REC is between 0 and 10, then Q15d. CERADJ7YES cannot be blank")]
         public bool? CeradJ7YesRequired
         {
@@ -1132,6 +1168,24 @@ namespace UDS.Net.Forms.Models.UDS4
         [NotMapped]
         [RequiredIfRange(nameof(UDSVERFC), 95, 98, ErrorMessage = "If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank")]
         public bool? UDSVERFCReasonCodeValidation
+        {
+            get
+            {
+                if ((UDSVERFC.HasValue && UDSVERFC >= 95) || (UDSVERLC.HasValue && UDSVERLC.Value >= 95))
+                {
+                    if (UDSVERTN == null && UDSVERTE == null && UDSVERTI == null)
+                    {
+                        return true;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        [NotMapped]
+        [RequiredIfRange(nameof(UDSVERFC), 95, 98, ErrorMessage = "If UDSVERFC (correct f-words) is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank")]
+        public bool? UDSVERFCValueValidation
         {
             get
             {

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -905,6 +905,7 @@
                         </div>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFC"></span>
                         <submission-error location="UDSVERFC" errors="Model.BaseForm.UnresolvedErrors" />
+                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                     </div>
 
                     <div class="@rowCSS">

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -905,7 +905,6 @@
                         </div>
                         <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFC"></span>
                         <submission-error location="UDSVERFC" errors="Model.BaseForm.UnresolvedErrors" />
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                     </div>
 
                     <div class="@rowCSS">
@@ -978,7 +977,10 @@
                     </div>
 
                     <div class="@rowCSS">
-                        <label asp-for="C2.UDSVERTN"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTN)</label>
+                        <div>
+                            <label asp-for="C2.UDSVERTN"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTN)</label>
+                            <p class="text-nowrap text-xs">(If questions 11a OR 11d are 95-98, then 11g MUST BE BLANK )</p>
+                        </div>
                         <div class="flex flex-row space-x-4">
                             <div class="min-w-[80px] max-w-[115px]">
                                 <input asp-for="@Model.C2.UDSVERTN" />
@@ -989,12 +991,16 @@
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTN"></span>
                             <submission-error location="UDSVERTN" errors="Model.BaseForm.UnresolvedErrors" />
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValidation"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                             <submission-error location="UDSVERTNValidation" errors="Model.BaseForm.UnresolvedErrors" />
                         </div>
                     </div>
 
                     <div class="@rowCSS">
-                        <label asp-for="C2.UDSVERTE"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTE)</label>
+                        <div>
+                            <label asp-for="C2.UDSVERTE"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTE)</label>
+                            <p class="text-nowrap text-xs">(If questions 11a OR 11d are 95-98, then 11h MUST BE BLANK )</p>
+                        </div>
                         <div class="flex flex-row space-x-4">
                             <div class="min-w-[80px] max-w-[115px]">
                                 <input asp-for="@Model.C2.UDSVERTE" />
@@ -1005,12 +1011,16 @@
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTE"></span>
                             <submission-error location="UDSVERTE" errors="Model.BaseForm.UnresolvedErrors" />
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValidation"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                             <submission-error location="UDSVERTEValidation" errors="Model.BaseForm.UnresolvedErrors" />
                         </div>
                     </div>
 
                     <div class="@rowCSS">
-                        <label asp-for="C2.UDSVERTI"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTI)</label>
+                        <div>
+                            <label asp-for="C2.UDSVERTI"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTI)</label>
+                            <p class="text-nowrap text-xs">(If questions 11a OR 11d are 95-98, then 11i MUST BE BLANK )</p>
+                        </div>
                         <div class="flex flex-row space-x-4">
                             <div class="min-w-[80px] max-w-[115px]">
                                 <input asp-for="@Model.C2.UDSVERTI" />
@@ -1020,6 +1030,7 @@
                         <div>
                             <div>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                                 <submission-error location="UDSVERTI" errors="Model.BaseForm.UnresolvedErrors" />
                             </div>
                             <div>

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -988,10 +988,10 @@
                             <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTN"></p>
                         </div>
                         <div>
-                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTN"></span>
                             <submission-error location="UDSVERTN" errors="Model.BaseForm.UnresolvedErrors" />
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValueValidation"></span>
                             <submission-error location="UDSVERTNValidation" errors="Model.BaseForm.UnresolvedErrors" />
                         </div>
                     </div>
@@ -1008,10 +1008,10 @@
                             <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTE"></p>
                         </div>
                         <div>
-                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTE"></span>
                             <submission-error location="UDSVERTE" errors="Model.BaseForm.UnresolvedErrors" />
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValueValidation"></span>
                             <submission-error location="UDSVERTEValidation" errors="Model.BaseForm.UnresolvedErrors" />
                         </div>
                     </div>
@@ -1029,7 +1029,6 @@
                         </div>
                         <div>
                             <div>
-                                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                                 <submission-error location="UDSVERTI" errors="Model.BaseForm.UnresolvedErrors" />
                             </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2.cshtml
@@ -989,6 +989,7 @@
                         </div>
                         <div>
                             <submission-error location="UDSVERTN" errors="Model.BaseForm.UnresolvedErrors" />
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTN"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValueValidation"></span>
@@ -1009,6 +1010,7 @@
                         </div>
                         <div>
                             <submission-error location="UDSVERTE" errors="Model.BaseForm.UnresolvedErrors" />
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTE"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValueValidation"></span>
@@ -1029,10 +1031,9 @@
                         </div>
                         <div>
                             <div>
+                                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                                 <submission-error location="UDSVERTI" errors="Model.BaseForm.UnresolvedErrors" />
-                            </div>
-                            <div>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTIValidation"></span>
                                 <submission-error location="UDSVERTIValidation" errors="Model.BaseForm.UnresolvedErrors" />
                             </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
@@ -1230,35 +1230,50 @@
                     </div>
 
                     <div class="@rowCSS">
-                        <label asp-for="C2.UDSVERTN"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTN)</label>
+                        <div>
+                            <label asp-for="C2.UDSVERTN"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTN)</label>
+                            <p class="text-nowrap text-xs">(If questions 12a OR 12d are 95-98, then 12g MUST BE BLANK )</p>
+                        </div>
                         <div class="flex flex-row space-x-4">
                             <div class="min-w-[80px] max-w-[115px]">
                                 <input asp-for="@Model.C2.UDSVERTN" />
                             </div>
                             <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTN"></p>
                         </div>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTN"></span>
-                        <submission-error location="UDSVERTN" errors="Model.BaseForm.UnresolvedErrors" />
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValidation"></span>
-                        <submission-error location="UDSVERTNValidation" errors="Model.BaseForm.UnresolvedErrors" />
+                        <div>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTN"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
+                            <submission-error location="UDSVERTN" errors="Model.BaseForm.UnresolvedErrors" />
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValidation"></span>
+                            <submission-error location="UDSVERTNValidation" errors="Model.BaseForm.UnresolvedErrors" />
+                        </div>
                     </div>
 
                     <div class="@rowCSS">
-                        <label asp-for="C2.UDSVERTE"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTE)</label>
+                        <div>
+                            <label asp-for="C2.UDSVERTE"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTE)</label>
+                            <p class="text-nowrap text-xs">(If questions 12a OR 12d are 95-98, then 12h MUST BE BLANK )</p>
+                        </div>
                         <div class="flex flex-row space-x-4">
                             <div class="min-w-[80px] max-w-[115px]">
                                 <input asp-for="@Model.C2.UDSVERTE" />
                             </div>
                             <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTE"></p>
                         </div>
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTE"></span>
-                        <submission-error location="UDSVERTE" errors="Model.BaseForm.UnresolvedErrors" />
-                        <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValidation"></span>
-                        <submission-error location="UDSVERTEValidation" errors="Model.BaseForm.UnresolvedErrors" />
+                        <div>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTE"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
+                            <submission-error location="UDSVERTE" errors="Model.BaseForm.UnresolvedErrors" />
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValidation"></span>
+                            <submission-error location="UDSVERTEValidation" errors="Model.BaseForm.UnresolvedErrors" />
+                        </div>
                     </div>
 
                     <div class="@rowCSS">
-                        <label asp-for="C2.UDSVERTI"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTI)</label>
+                        <div>
+                            <label asp-for="C2.UDSVERTI"><span class="subcounter"></span> @Html.DisplayNameFor(m => m.C2.UDSVERTI)</label>
+                            <p class="text-nowrap text-xs">(If questions 12a OR 12d are 95-98, then 12i MUST BE BLANK )</p>
+                        </div>
                         <div class="flex flex-row space-x-4">
                             <div class="min-w-[80px] max-w-[115px]">
                                 <input asp-for="@Model.C2.UDSVERTI" />
@@ -1268,6 +1283,7 @@
                         <div>
                             <div>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
+                                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                                 <submission-error location="UDSVERTI" errors="Model.BaseForm.UnresolvedErrors" />
                             </div>
                             <div>

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
@@ -1241,6 +1241,7 @@
                             <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTN"></p>
                         </div>
                         <div>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTN"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValueValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                             <submission-error location="UDSVERTN" errors="Model.BaseForm.UnresolvedErrors" />
@@ -1263,6 +1264,7 @@
                         <div>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValueValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTE"></span>
                             <submission-error location="UDSVERTE" errors="Model.BaseForm.UnresolvedErrors" />
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValidation"></span>
                             <submission-error location="UDSVERTEValidation" errors="Model.BaseForm.UnresolvedErrors" />
@@ -1282,6 +1284,7 @@
                         </div>
                         <div>
                             <div>
+                                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                                 <submission-error location="UDSVERTI" errors="Model.BaseForm.UnresolvedErrors" />
                             </div>

--- a/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
+++ b/src/UDS.Net.Forms/Pages/UDS4/_C2T.cshtml
@@ -1241,7 +1241,7 @@
                             <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTN"></p>
                         </div>
                         <div>
-                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTN"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValueValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                             <submission-error location="UDSVERTN" errors="Model.BaseForm.UnresolvedErrors" />
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTNValidation"></span>
@@ -1261,7 +1261,7 @@
                             <p class="text-sm text-gray-500 text-nowrap" asp-description-for="@Model.C2.UDSVERTE"></p>
                         </div>
                         <div>
-                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTE"></span>
+                            <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValueValidation"></span>
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                             <submission-error location="UDSVERTE" errors="Model.BaseForm.UnresolvedErrors" />
                             <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTEValidation"></span>
@@ -1282,7 +1282,6 @@
                         </div>
                         <div>
                             <div>
-                                <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERTI"></span>
                                 <span class="mt-2 text-sm text-red-600" asp-validation-for="C2.UDSVERFCReasonCodeValidation"></span>
                                 <submission-error location="UDSVERTI" errors="Model.BaseForm.UnresolvedErrors" />
                             </div>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.14-preview.4</Version>
+		<Version>17.0.14-preview.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.13</Version>
+		<Version>17.0.14-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.13</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.14-preview.1</Version>
+		<Version>17.0.14-preview.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.14-preview.3</Version>
+		<Version>17.0.14-preview.4</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.14-preview.6</Version>
+		<Version>17.0.14-preview.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.14-preview.7</Version>
+		<Version>17.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
+		<ReleaseVersion>17.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Forms/UDS.Net.Forms.csproj
+++ b/src/UDS.Net.Forms/UDS.Net.Forms.csproj
@@ -6,13 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>UDS.Net.Forms</PackageId>
-		<Version>17.0.14-preview.5</Version>
+		<Version>17.0.14-preview.6</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS Forms razor class library</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Razor class library for rendering UDS forms</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.13</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
+		<ReleaseVersion>17.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
+++ b/src/UDS.Net.Services.Test/UDS.Net.Services.Test.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.14-preview.5</Version>
+		<Version>17.0.14-preview.6</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.14-preview.6</Version>
+		<Version>17.0.14-preview.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.14-preview.4</Version>
+		<Version>17.0.14-preview.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.14-preview.2</Version>
+		<Version>17.0.14-preview.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.13</Version>
+		<Version>17.0.14-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.13</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.14-preview.7</Version>
+		<Version>17.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
+		<ReleaseVersion>17.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.14-preview.3</Version>
+		<Version>17.0.14-preview.4</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Services/UDS.Net.Services.csproj
+++ b/src/UDS.Net.Services/UDS.Net.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Services</PackageId>
-		<Version>17.0.14-preview.1</Version>
+		<Version>17.0.14-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Service contracts for implmenting your own back-end with MVC web app</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Service contracts required by MVC web app</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="UDS.Net.Dto" Version="11.0.5" />

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.14-preview.3</Version>
+		<Version>17.0.14-preview.4</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.14-preview.7</Version>
+		<Version>17.0.14</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
+		<ReleaseVersion>17.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.14-preview.1</Version>
+		<Version>17.0.14-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.14-preview.2</Version>
+		<Version>17.0.14-preview.3</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.14-preview.4</Version>
+		<Version>17.0.14-preview.5</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.14-preview.5</Version>
+		<Version>17.0.14-preview.6</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.14-preview.6</Version>
+		<Version>17.0.14-preview.7</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
+++ b/src/UDS.Net.Web.MVC.Services/UDS.Net.Web.MVC.Services.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.MVC.Services</PackageId>
-		<Version>17.0.13</Version>
+		<Version>17.0.14-preview.1</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>Implemented service layer for using MVC front-end with API back-end</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Implemented service contract</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-web</RepositoryUrl>
-		<ReleaseVersion>17.0.13</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<ItemGroup>

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.14-preview.5</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.6</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.13</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.14-preview.7</ReleaseVersion>
+		<ReleaseVersion>17.0.14</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
+++ b/src/UDS.Net.Web.MVC/UDS.Net.Web.MVC.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>aspnet-UDS.Net.Web.MVC-F92C0881-61B6-4292-8635-0004DE84CFE6</UserSecretsId>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
-		<ReleaseVersion>17.0.14-preview.3</ReleaseVersion>
+		<ReleaseVersion>17.0.14-preview.4</ReleaseVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />


### PR DESCRIPTION
Resolves #721 

### Add new validation to the C2 form
Josh discovered new validation added to the C2 form that needed to be added to our existing validation logic

#### New validation rule
> If UDSVERFC (correct f-words is between 95 and 98 or UDSVERLC (I-words correct) is between 95 and 98, then UDSVERTN, UDSVERTE, and UDSVERTI must be blank

<img width="1841" height="337" alt="image" src="https://github.com/user-attachments/assets/8f5a7e32-2157-4a32-a59d-ebe68ea43e49" />

- [ ] Add new validation logic to C2 form (both in person and remote views for the C2)
- [ ] Add new validation messages to C2 view
- [ ] Add new validation messages to C2T view
- [ ] Helper text added under labels for questions: UDSVERTN, UDSVERTE, UDSVERTI

### Comments
- The label helper text for the in person and remote views references their corresponding views
- The error text refers to the property name due to the properties being different question numbers on each view
- The validation for UDSVERFC = 95 - 98 triggers on finalize, while UDSVERLC already disables the fields on 95 - 98